### PR TITLE
OM-730 | Add new account

### DIFF
--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -3,6 +3,7 @@ noAccount=I don't have a Helsinki account yet
 doRegister=Create a new Helsinki account
 doRegisterShort=Create account
 backToLogin=Cancel
+doAcknowledgeResources=I have read the privacy policy of the City of Helsinki
 
 # logo
 helsinkiLogo=helsinki-logo

--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -1,6 +1,8 @@
 forgotPassword=I forgot my password
 noAccount=I don't have a Helsinki account yet
-doRegister=Create s new Helsinki account
+doRegister=Create a new Helsinki account
+doRegisterShort=Create account
+backToLogin=Cancel
 
 # logo
 helsinkiLogo=helsinki-logo

--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -1,0 +1,86 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout; section>
+    <#if section = "header">
+        ${msg("registerTitle")}
+    <#elseif section = "form">
+        <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
+            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('firstName',properties.kcFormGroupErrorClass!)}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="firstName" class="${properties.kcLabelClass!}">${msg("firstName")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="text" id="firstName" class="${properties.kcInputClass!}" name="firstName" value="${(register.formData.firstName!'')}" />
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('lastName',properties.kcFormGroupErrorClass!)}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="lastName" class="${properties.kcLabelClass!}">${msg("lastName")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="text" id="lastName" class="${properties.kcInputClass!}" name="lastName" value="${(register.formData.lastName!'')}" />
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('email',properties.kcFormGroupErrorClass!)}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="email" class="${properties.kcLabelClass!}">${msg("email")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="text" id="email" class="${properties.kcInputClass!}" name="email" value="${(register.formData.email!'')}" autocomplete="email" />
+                </div>
+            </div>
+
+          <#if !realm.registrationEmailAsUsername>
+            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('username',properties.kcFormGroupErrorClass!)}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="username" class="${properties.kcLabelClass!}">${msg("username")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="text" id="username" class="${properties.kcInputClass!}" name="username" value="${(register.formData.username!'')}" autocomplete="username" />
+                </div>
+            </div>
+          </#if>
+
+            <#if passwordRequired??>
+            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('password',properties.kcFormGroupErrorClass!)}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="password" id="password" class="${properties.kcInputClass!}" name="password" autocomplete="new-password"/>
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('password-confirm',properties.kcFormGroupErrorClass!)}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="password" id="password-confirm" class="${properties.kcInputClass!}" name="password-confirm" />
+                </div>
+            </div>
+            </#if>
+
+            <#if recaptchaRequired??>
+            <div class="form-group">
+                <div class="${properties.kcInputWrapperClass!}">
+                    <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                </div>
+            </div>
+            </#if>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                        <span><a href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a></span>
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>
+                </div>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -71,14 +71,9 @@
             </#if>
 
             <div class="${properties.kcFormGroupClass!}">
-                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-                    <div class="${properties.kcFormOptionsWrapperClass!}">
-                        <span><a href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a></span>
-                    </div>
-                </div>
-
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
-                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>
+                    <a class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a>
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegisterShort")}"/>
                 </div>
             </div>
         </form>

--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -70,6 +70,16 @@
             </div>
             </#if>
 
+            <!-- This element is only used with custom validation. Its value is ephemeral. -->
+            <!-- 1. It doesn't get saved into server -->
+            <!-- 2. It doesn't persist over page reloads -->
+            <div id="hs-acknowledgements-form-group" class="${properties.kcFormGroupClass!}">
+                <div class="hs-checkbox">
+                    <input class="hs-checkbox__box" type="checkbox" name="acknowledgements" id="hs-acknowledgements" />
+                    <label for="acknowledgements" class="hs-checkbox__label">${kcSanitize(msg("doAcknowledgeResources"))}</label>
+                </div>
+            </div>
+
             <div class="${properties.kcFormGroupClass!}">
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
                     <a class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a>

--- a/helsinki/login/resources/js/customRegistrationValidation.js
+++ b/helsinki/login/resources/js/customRegistrationValidation.js
@@ -1,0 +1,87 @@
+(function () {
+  // <-- Constants
+  var HS_HAS_ERROR_CLASS = "hs-has-error";
+  var KC_REGISTER_FORM_ID = "kc-register-form";
+  var HS_ACKNOWLEDGEMENTS_FORM_GROUP_ID = "hs-acknowledgements-form-group";
+  var HS_ACKNOWLEDGEMENTS_INPUT_ID = "hs-acknowledgements";
+  // --> Constants
+
+  // <-- Selectors
+  function getRegistrationForm() {
+    return document.getElementById(KC_REGISTER_FORM_ID);
+  }
+  function getHsAcknowledgementsFormGroup() {
+    return document.getElementById(HS_ACKNOWLEDGEMENTS_FORM_GROUP_ID);
+  }
+  function getHsAcknowledgementsInput() {
+    return document.getElementById(HS_ACKNOWLEDGEMENTS_INPUT_ID);
+  }
+  // --> Selectors
+
+  // <-- Utils
+  function getIsAcknowledgementsValid(acknowledgementsElement) {
+    return acknowledgementsElement.checked === true;
+  }
+  // --> Utils
+
+  // <-- Handlers
+  var handleRegistrationFormSubmit = function (event) {
+    var isAcknowledgedValid = getIsAcknowledgementsValid(
+      event.target.acknowledgements
+    );
+
+    // Toggle the error class in the acknowledgement form group.
+    getHsAcknowledgementsFormGroup().classList.toggle(
+      HS_HAS_ERROR_CLASS,
+      !isAcknowledgedValid
+    );
+
+    // If our custom conditions do not pass, we prevent the form from
+    // submitting. Note that this behaviour will in essence create two
+    // validation steps if the user has multiple errors on the form:
+    // 1) Custom validation is ran in the browser
+    // 2) Default validation is ran on the server
+    //
+    // This means that the user may have to fix errors twice. Not ideal
+    // but this seemed like the most pragmatic approach.
+    if (!isAcknowledgedValid) {
+      event.preventDefault();
+    }
+  };
+  var handleHsAcknowledgementsChange = function (event) {
+    var hsAcknowledgementsFormGroup = getHsAcknowledgementsFormGroup();
+    var isError = hsAcknowledgementsFormGroup.classList.contains(
+      HS_HAS_ERROR_CLASS
+    );
+    var isNowValid = getIsAcknowledgementsValid(event.target);
+
+    // When the form group still has an error label, but actually has a
+    // valid value, remove the error value.
+    if (isError && isNowValid) {
+      hsAcknowledgementsFormGroup.classList.remove(HS_HAS_ERROR_CLASS);
+    }
+  };
+  // --> Handlers
+
+  document.addEventListener("DOMContentLoaded", function (event) {
+    getRegistrationForm().addEventListener(
+      "submit",
+      handleRegistrationFormSubmit
+    );
+    getHsAcknowledgementsInput().addEventListener(
+      "change",
+      handleHsAcknowledgementsChange
+    );
+  });
+
+  window.onunload = function () {
+    getRegistrationForm().removeEventListener(
+      "submit",
+      handleRegistrationFormSubmit
+    );
+    getHsAcknowledgementsInput().removeEventListener(
+      "change",
+      handleHsAcknowledgementsChange
+    );
+  };
+})();

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -4,6 +4,9 @@ import=common/keycloak
 # Inherit styles from parent and use custom css files
 styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/helsinki-grotesk.css css/hds.css css/custom.css
 
+# Add custom JS hooks
+scripts=js/customRegistrationValidation.js
+
 # Custom property that can be used to hide the header
 showHeader=false
 

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -37,3 +37,11 @@ kcInputClass=hds-text-input__input
 kcLabelClass=hds-text-input__label
 # class for form groups
 kcFormGroupClass=hs-form-group
+# These keycloak theme uses these two classes to implement a column
+# layout. It relies on the kcFormGroupClass to reset floats. As we do
+# not need columns, I'm just resetting these classes in order to avoid
+# the need for creating unused markup.
+kcLabelWrapperClass=
+kcInputWrapperClass=
+kcFormOptionsClass=
+kcFormButtonsClass=

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -44,4 +44,4 @@ kcFormGroupClass=hs-form-group
 kcLabelWrapperClass=
 kcInputWrapperClass=
 kcFormOptionsClass=
-kcFormButtonsClass=
+kcFormButtonsClass=hs-button-row

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -171,7 +171,9 @@ a.hds-button--supplementary {
 // Form group
 // Sets whitespace according to HDS
 .hs-form-group {
-  margin-bottom: $spacing-layout-s;
+  &:not(:last-child) {
+    margin-bottom: $spacing-layout-s;
+  }
 }
 
 // Custom block 

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -228,3 +228,12 @@ a.hds-button--supplementary {
   font-size: $font-size-5;
   font-weight: bold;
 }
+
+// Custom button wrapper
+// A wrapping block element that positions two button side by side with
+// margin in between.
+.hs-button-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-column-gap: $spacing-xs;
+}

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -177,6 +177,11 @@ a.hds-button--supplementary {
   }
 }
 
+// Apply error colours
+.hs-has-error.hs-form-group {
+  color: $color-error;
+}
+
 // Tee registration page has a longer form, which is why the designer
 // has used a smaller spacing for it. Most forms in this app are short
 // so we are treating the condensed form as a special case.
@@ -236,4 +241,58 @@ a.hds-button--supplementary {
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-column-gap: $spacing-xs;
+}
+
+// Custom checkbox component copied from open-city-profile
+.hs-checkbox {
+  margin: 10px 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+
+  &__box {
+    margin: 0 !important;
+    position: relative;
+    min-width: 20px;
+    min-height: 20px;
+    -webkit-appearance: none;
+
+    background-color: $color-white;
+    // Custom colour that does not exist in the style system yet (?)
+    border: 2px solid #c4c4c4;
+    border-radius: 1px;
+
+    // If the form group has an error, set checkbox into error state.
+    .hs-has-error & {
+      border-color: $color-error;
+    }
+
+    &:checked {
+      color: $color-white;
+
+      background-color: $color-bus-dark-50;
+      border-color: $color-bus-dark-50;
+      
+      &:after {
+        content: '\2714';
+        position: absolute;
+        top: -1px;
+        left: 2px;
+
+        font-size: $font-size-body-default;
+        color: $color-white;
+      }
+
+      &:focus {
+        outline: none;
+      }
+    }
+  }
+
+  &__label {
+    margin:  0 0 0 $spacing-xs;
+
+    font-size: $font-size-body-default;
+    font-weight: normal;
+  }
 }

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -169,10 +169,21 @@ a.hds-button--supplementary {
 }
 
 // Form group
+
 // Sets whitespace according to HDS
 .hs-form-group {
   &:not(:last-child) {
     margin-bottom: $spacing-layout-s;
+  }
+}
+
+// Tee registration page has a longer form, which is why the designer
+// has used a smaller spacing for it. Most forms in this app are short
+// so we are treating the condensed form as a special case.
+
+#kc-register-form .hs-form-group {
+  &:not(:last-child) {
+    margin-bottom: $spacing-layout-xs;
   }
 }
 


### PR DESCRIPTION
These changes add an initial version of the registration page

<img width="597" alt="Screenshot 2020-04-29 at 11 44 12" src="https://user-images.githubusercontent.com/9090689/80577016-d3742180-8a0e-11ea-831a-98376236145d.png">

Errors still need to be presented inline. I'll do this in another PR in order to limit the amount of changes for a single PR.

**Custom field for acknowledging privacy policy**  

I've added a custom field that I enforce by adding an extra validation phase. Now, instead of a single validation on the server, a pre-validation is completed in the browser with the help of JS.

Note that I implemented this functionality in "Vanilla JS". I attempted to avoid external dependencies in order to keep the project lightweight. I also think that we should avoid adding to the custom JS layer if possible, so I didn't want to spend a lot of effort setting something up we shouldn't, in my opinion, use that much.

I implemented the JS to the best of my ability. We don't support IE11 so I think that the notation should be OK, but some time has passed since I've written JS on this low of a level so I'm not confident.