### PR TITLE
OM-730 | Add inline erros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add integration to hds-core
 - Add HelsinkiGrotesk font family
 - Add support for login page
+- Add support for registration page

--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout; section>
+<@layout.registrationLayout showAlerts=false; section>
     <#if section = "header">
         ${msg("registerTitle")}
     <#elseif section = "form">
@@ -9,7 +9,15 @@
                     <label for="firstName" class="${properties.kcLabelClass!}">${msg("firstName")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="firstName" class="${properties.kcInputClass!}" name="firstName" value="${(register.formData.firstName!'')}" />
+                    <div class="${properties.hsInputwrapperClass!}">
+                        <input type="text" id="firstName" class="${properties.kcInputClass!}" name="firstName" value="${(register.formData.firstName!'')}" />
+                        <#if messagesPerField.firstName != "">
+                            <span class="${properties.hsIconClass!} ${properties.hsAttentionIconClass!}"></span>
+                        </#if>
+                    </div>
+                    <#if messagesPerField.firstName != "">
+                        <div class="${properties.hsInputHelperText!}">${messagesPerField.firstName}</div>
+                    </#if>
                 </div>
             </div>
 
@@ -18,7 +26,15 @@
                     <label for="lastName" class="${properties.kcLabelClass!}">${msg("lastName")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="lastName" class="${properties.kcInputClass!}" name="lastName" value="${(register.formData.lastName!'')}" />
+                    <div class="${properties.hsInputwrapperClass!}">
+                        <input type="text" id="lastName" class="${properties.kcInputClass!}" name="lastName" value="${(register.formData.lastName!'')}" />
+                        <#if messagesPerField.lastName != "">
+                            <span class="${properties.hsIconClass!} ${properties.hsAttentionIconClass!}"></span>
+                        </#if>
+                    </div>
+                    <#if messagesPerField.lastName != "">
+                        <div class="${properties.hsInputHelperText!}">${messagesPerField.lastName}</div>
+                    </#if>
                 </div>
             </div>
 
@@ -27,7 +43,15 @@
                     <label for="email" class="${properties.kcLabelClass!}">${msg("email")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="email" class="${properties.kcInputClass!}" name="email" value="${(register.formData.email!'')}" autocomplete="email" />
+                    <div class="${properties.hsInputwrapperClass!}">
+                        <input type="text" id="email" class="${properties.kcInputClass!}" name="email" value="${(register.formData.email!'')}" autocomplete="email" />
+                        <#if messagesPerField.email != "">
+                            <span class="${properties.hsIconClass!} ${properties.hsAttentionIconClass!}"></span>
+                        </#if>
+                    </div>
+                    <#if messagesPerField.email != "">
+                        <div class="${properties.hsInputHelperText!}">${messagesPerField.email}</div>
+                    </#if>
                 </div>
             </div>
 
@@ -37,7 +61,15 @@
                     <label for="username" class="${properties.kcLabelClass!}">${msg("username")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="text" id="username" class="${properties.kcInputClass!}" name="username" value="${(register.formData.username!'')}" autocomplete="username" />
+                    <div class="${properties.hsInputwrapperClass!}">
+                        <input type="text" id="username" class="${properties.kcInputClass!}" name="username" value="${(register.formData.username!'')}" autocomplete="username" />
+                        <#if messagesPerField.username != "">
+                            <span class="${properties.hsIconClass!} ${properties.hsAttentionIconClass!}"></span>
+                        </#if>
+                    </div>
+                    <#if messagesPerField.username != "">
+                        <div class="${properties.hsInputHelperText!}">${messagesPerField.username}</div>
+                    </#if>
                 </div>
             </div>
           </#if>
@@ -48,7 +80,15 @@
                     <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password" class="${properties.kcInputClass!}" name="password" autocomplete="new-password"/>
+                    <div class="${properties.hsInputwrapperClass!}">
+                        <input type="password" id="password" class="${properties.kcInputClass!}" name="password" autocomplete="new-password"/>
+                        <#if messagesPerField.password != "">
+                            <span class="${properties.hsIconClass!} ${properties.hsAttentionIconClass!}"></span>
+                        </#if>
+                    </div>
+                    <#if messagesPerField.password != "">
+                        <div class="${properties.hsInputHelperText!}">${messagesPerField.password}</div>
+                    </#if>
                 </div>
             </div>
 
@@ -57,7 +97,15 @@
                     <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
-                    <input type="password" id="password-confirm" class="${properties.kcInputClass!}" name="password-confirm" />
+                    <div class="${properties.hsInputwrapperClass!}">
+                        <input type="password" id="password-confirm" class="${properties.kcInputClass!}" name="password-confirm" />
+                        <#if messagesPerField["password-confirm"] != "">
+                            <span class="${properties.hsIconClass!} ${properties.hsAttentionIconClass!}"></span>
+                        </#if>
+                    </div>
+                    <#if messagesPerField["password-confirm"] != "">
+                        <div class="${properties.hsInputHelperText!}">${messagesPerField["password-confirm"]}</div>
+                    </#if>
                 </div>
             </div>
             </#if>

--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -123,7 +123,10 @@
             <!-- 2. It doesn't persist over page reloads -->
             <div id="hs-acknowledgements-form-group" class="${properties.kcFormGroupClass!}">
                 <div class="hs-checkbox">
-                    <input class="hs-checkbox__box" type="checkbox" name="acknowledgements" id="hs-acknowledgements" />
+                    <div class="hs-checkbox__box-wrapper">
+                        <input class="hs-checkbox__box" type="checkbox" name="acknowledgements" id="hs-acknowledgements" />
+                        <span class="${properties.hsIconClass!} ${properties.hsCheckIconClass!} hs-checkbox__tick"></span>
+                    </div>
                     <label for="acknowledgements" class="hs-checkbox__label">${kcSanitize(msg("doAcknowledgeResources"))}</label>
                 </div>
             </div>

--- a/helsinki/login/template.ftl
+++ b/helsinki/login/template.ftl
@@ -1,4 +1,4 @@
-<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false displayWide=false showAnotherWayIfPresent=true>
+<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false displayWide=false showAnotherWayIfPresent=true showAlerts=true>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" class="${properties.kcHtmlClass!}">
 
@@ -111,7 +111,7 @@
 
           <#-- App-initiated actions should not see warning messages about the need to complete the action -->
           <#-- during login.                                                                               -->
-          <#if displayMessage && message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
+          <#if showAlerts && displayMessage && message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
               <div class="${properties.hsAlertClass!}<#if message.type = 'success'> ${properties.hsAlertSuccessClass!}</#if><#if message.type = 'warning'> ${properties.hsAlertWarningClass!}</#if><#if message.type = 'error'> ${properties.hsAlertErrorClass!}</#if><#if message.type = 'info'> ${properties.hsAlertInfoClass!}</#if>">
                   <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
                   <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -2,7 +2,7 @@ parent=keycloak
 import=common/keycloak
 
 # Inherit styles from parent and use custom css files
-styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/helsinki-grotesk.css css/hds.css css/custom.css
+styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/helsinki-grotesk.css css/hds.css css/keycloak-overrides.css css/hds-overrides.css css/custom.css
 
 # Add custom JS hooks
 scripts=js/customRegistrationValidation.js

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -29,6 +29,7 @@ hsInputwrapperClass=hs-input-wrapper
 # icons inherited from hds
 hsIconClass=hds-icon
 hsAttentionIconClass=hds-icon--attention
+hsCheckIconClass=hds-icon--check
 
 ##### css classes for form buttons
 # main class used for all buttons

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -22,6 +22,13 @@ hsAlertWarningClass=hds-notification--warning
 hsAlertErrorClass=hds-notification--error
 hsAlertInfoClass=
 hsAlertLabelClass=hds-notification__label
+# Used for input level help texts
+hsInputHelperText=hds-text-input__helper-text
+# custom input wrapper that is used to position input icons
+hsInputwrapperClass=hs-input-wrapper
+# icons inherited from hds
+hsIconClass=hds-icon
+hsAttentionIconClass=hds-icon--attention
 
 ##### css classes for form buttons
 # main class used for all buttons
@@ -48,3 +55,5 @@ kcLabelWrapperClass=
 kcInputWrapperClass=
 kcFormOptionsClass=
 kcFormButtonsClass=hs-button-row
+# class that sets a form group into error state
+kcFormGroupErrorClass=hs-has-error

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "scripts": {
     "build": "npm run build:sass",
-    "build:sass": "mkdir -p helsinki/login/resources/css && npm run build:sass:hds && npm run build:sass:custom && npm run build:sass:helsinkiGrotesk",
+    "build:sass": "mkdir -p helsinki/login/resources/css && npm run build:sass:hds && npm run build:sass:custom && npm run build:sass:helsinkiGrotesk && npm run build:sass:keycloakOverrides && npm run build:sass:hdsOverrides",
     "build:sass:hds": "npm-sass sass/hds.scss > helsinki/login/resources/css/hds.css",
     "build:sass:custom": "npm-sass sass/custom.scss > helsinki/login/resources/css/custom.css",
     "build:sass:helsinkiGrotesk": "npm-sass sass/helsinki-grotesk.scss > helsinki/login/resources/css/helsinki-grotesk.css",
+    "build:sass:keycloakOverrides": "npm-sass sass/keycloak-overrides.scss > helsinki/login/resources/css/keycloak-overrides.css",
+    "build:sass:hdsOverrides": "npm-sass sass/hds-overrides.scss > helsinki/login/resources/css/hds-overrides.css",
     "clean": "rm -rf helsinki/login/resources/css/"
   },
   "dependencies": {

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -11,79 +11,6 @@ html {
   color: $color-black-90;
 }
 
-// OVERRIDES
-
-// Override the default background image with a solid color
-.login-pf {
-  background: $light-blue;
-}
-.login-pf body {
-  background: none;
-}
-
-// Use correct typography for page title
-#kc-page-title {
-  margin-top: 0;
-  margin-bottom: $spacing-layout-xs;
-
-  font-size: $font-size-2;
-  font-weight: bold;
-  text-align: unset;
-}
-
-// Use correct whitespace for login page
-.login-pf-page .card-pf {
-  padding: $spacing-layout-m;
-}
-
-.login-pf-page .login-pf-header {
-  margin-bottom: 0;
-}
-
-.card-pf {
-  max-width: 580px;
-}
-
-// Use correct whitespace for button container
-#kc-form-buttons {
-  margin-top: $spacing-layout-m;
-}
-
-// Unset text-align in order to ignore centered text
-.login-pf-page .login-pf-signup {
-  text-align: unset;
-}
-
-// Ignore margin that is used for inlined elements in original theme.
-// In the helsinki theme these elements are no longer inlined.
-.login-pf-page .login-pf-signup a {
-  margin-left: unset;
-}
-
-// Ignore margin that is used to separate form elements from info
-// elements
-.login-pf-page .login-pf-signup {
-  margin: unset;
-}
-
-// Ignore margin that breaks padding. It's on an element that should be 
-// the last element on pages. If it ends up not being that, set a margin
-// with &:not(:last-child).
-#kc-registration {
-  margin-bottom: unset;
-}
-
-// Set alert icon size to match that in design files
-.hds-notification .pficon {
-  position: relative;
-  bottom: -4px; // Center vertically
-  width: 24px;
-  height: 24px;
-  margin-right: $spacing-s;
-
-  font-size: 24px;
-}
-
 
 // CUSTOM STYLES
 
@@ -98,74 +25,6 @@ html {
   // corner instead of centering.
   object-fit: contain;
   object-position: 0 0;
-}
-
-// Input
-// NOTE: These styles will be available through HDS. Please refactor the
-// theme to use those when possible. I've used a class that should match
-// the class name in HDS, meaning that simply removing this rule should
-// be enough.
-.hds-text-input__input {
-  width: 100%;
-  padding: $spacing-xs 0.888em; // 0.888em = ~16px (not available through hds)
-
-  font-size: $font-size-5;
-  line-height: 1.666; // ~30px
-
-  border-width: 2px;
-  border-style: solid;
-  border-radius: 1px;
-  border-color: $color-black-20;
-  background-color: inherit;
-
-  &:focus {
-    border-color: $color-black-90;
-  }
-
-  &::placeholder {
-    color: $color-black-30;
-  }
-}
-
-// Overriding HDS  Input label
-// HDS provides styles for the label element, but they are out of sync
-// with the definitions in the design side. These overrides fill the
-// gaps.
-.hds-text-input__label {
-  font-size: $font-size-body-small;
-}
-
-// Overriding HDS Button
-// The styles for HDS button seem are not precise enough to reproduce
-// the buttons authentically in this application. On top of this issue,
-// the buttons in the design files for this application use different
-// colours compared to what buttons in HDS use.
-
-// I've increased specificity for anchor elements because the base theme
-// uses naive selector that target all links within the login page that
-// break theme colours.
-
-.hds-button,
-a.hds-button {
-  font-size: $font-size-body-default;
-  font-weight: 600;
-  line-height: 1.625;
-}
-
-.hds-button--primary,
-a.hds-button--primary {
-  background-color: $color-primary;
-}
-
-.hds-button--supplementary,
-a.hds-button--supplementary {
-  color: $color-primary;
-
-  &:hover,
-  &:active,
-  &:focus {
-    color: $color-primary-dark;
-  }
 }
 
 // Form group
@@ -214,24 +73,6 @@ a.hds-button--supplementary {
   &:not(:last-child) {
     margin-bottom: $spacing-s;
   }
-}
-
-// Overriding HDS notification
-// The notification component uses the incorrect colours and font sizes
-
-.hds-notification {
-  padding: $spacing-s;
-
-  background-color: $color-error-light;
-  border-left-width: 0.25rem;
-  border-color: $color-error;
-}
-
-.hds-notification__label {
-  // This colour was in the design file, but it does not exists in HDS.
-  color: $color-error;
-  font-size: $font-size-5;
-  font-weight: bold;
 }
 
 // Custom button wrapper

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -137,3 +137,9 @@ html {
     font-weight: normal;
   }
 }
+
+// Input wrapper
+// Is used for positioning error icons
+.hs-input-wrapper {
+  position: relative;
+}

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -91,17 +91,23 @@ html {
   display: flex;
   align-items: center;
 
+  &__box-wrapper {
+    position: relative;
+  }
+
   &__box {
     margin: 0 !important;
     position: relative;
-    min-width: 20px;
-    min-height: 20px;
+    width: $spacing-layout-xs;
+    height: $spacing-layout-xs;
     -webkit-appearance: none;
 
-    background-color: $color-white;
+    // background-color: $color-white;
     // Custom colour that does not exist in the style system yet (?)
     border: 2px solid #c4c4c4;
     border-radius: 1px;
+    // mask-image: none;
+    // -webkit-mask-image: none;
 
     // If the form group has an error, set checkbox into error state.
     .hs-has-error & {
@@ -113,20 +119,29 @@ html {
 
       background-color: $color-bus-dark-50;
       border-color: $color-bus-dark-50;
-      
-      &:after {
-        content: '\2714';
-        position: absolute;
-        top: -1px;
-        left: 2px;
-
-        font-size: $font-size-body-default;
-        color: $color-white;
-      }
+      mask-image: initial;
+      -webkit-mask-image: initial;
 
       &:focus {
         outline: none;
       }
+    }
+  }
+
+  &__tick {
+    position: absolute;
+    left: 3px;
+    top: 5px;
+    width: 18px;
+    height: 14px;
+    display: none;
+
+    color: $color-white;
+
+    pointer-events: none;
+
+    .hs-checkbox__box:checked ~ & {
+      display: inline-block;
     }
   }
 

--- a/sass/hds-overrides.scss
+++ b/sass/hds-overrides.scss
@@ -1,0 +1,85 @@
+@import 'theme';
+
+// Input
+// NOTE: These styles will be available through HDS. Please refactor the
+// theme to use those when possible. I've used a class that should match
+// the class name in HDS, meaning that simply removing this rule should
+// be enough.
+.hds-text-input__input {
+  width: 100%;
+  padding: $spacing-xs 0.888em; // 0.888em = ~16px (not available through hds)
+
+  font-size: $font-size-5;
+  line-height: 1.666; // ~30px
+
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 1px;
+  border-color: $color-black-20;
+  background-color: inherit;
+
+  &:focus {
+    border-color: $color-black-90;
+  }
+
+  &::placeholder {
+    color: $color-black-30;
+  }
+}
+
+// Input label
+// HDS provides styles for the label element, but they are out of sync
+// with the definitions in the design side. These overrides fill the
+// gaps.
+.hds-text-input__label {
+  font-size: $font-size-body-small;
+}
+
+// Button
+// The styles for HDS button seem are not precise enough to reproduce
+// the buttons authentically in this application. On top of this issue,
+// the buttons in the design files for this application use different
+// colours compared to what buttons in HDS use.
+
+// I've increased specificity for anchor elements because the base theme
+// uses naive selector that target all links within the login page that
+// break theme colours.
+.hds-button,
+a.hds-button {
+  font-size: $font-size-body-default;
+  font-weight: 600;
+  line-height: 1.625;
+}
+
+.hds-button--primary,
+a.hds-button--primary {
+  background-color: $color-primary;
+}
+
+.hds-button--supplementary,
+a.hds-button--supplementary {
+  color: $color-primary;
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: $color-primary-dark;
+  }
+}
+
+
+// Notification
+// The notification component uses the incorrect colours and font sizes
+.hds-notification {
+  padding: $spacing-s;
+
+  background-color: $color-error-light;
+  border-left-width: 0.25rem;
+  border-color: $color-error;
+}
+.hds-notification__label {
+  // This colour was in the design file, but it does not exists in HDS.
+  color: $color-error;
+  font-size: $font-size-5;
+  font-weight: bold;
+}

--- a/sass/hds-overrides.scss
+++ b/sass/hds-overrides.scss
@@ -25,6 +25,11 @@
   &::placeholder {
     color: $color-black-30;
   }
+
+  // Use red border when the form group is in an error state.
+  .hs-has-error & {
+    border-color: $color-error;
+  }
 }
 
 // Input label
@@ -34,6 +39,18 @@
 .hds-text-input__label {
   font-size: $font-size-body-small;
 }
+
+// Input helper text
+// HDS provides some styles, but they are out of date.
+.hds-text-input__helper-text {
+  font-size: $font-size-body-small;
+
+  // Use red colour when the form group is in an error state.
+  .hs-has-error & {
+    color: $color-error;
+  }
+}
+
 
 // Button
 // The styles for HDS button seem are not precise enough to reproduce
@@ -82,4 +99,16 @@ a.hds-button--supplementary {
   color: $color-error;
   font-size: $font-size-5;
   font-weight: bold;
+}
+
+// Icons
+// Extend default styles to position icons correctly in input wrapper
+.hs-input-wrapper .hds-icon {
+  position: absolute;
+  right: $spacing-xs;
+  top: 50%;
+  width: $spacing-layout-xs;
+  height: $spacing-layout-xs;
+
+  transform: translateY(-50%);
 }

--- a/sass/hds.scss
+++ b/sass/hds.scss
@@ -1,2 +1,4 @@
 @import "hds-core/lib/helsinki";
 @import "hds-core/lib/components/all";
+@import "hds-core/lib/icons/icon";
+@import "hds-core/lib/icons/icon-attention";

--- a/sass/hds.scss
+++ b/sass/hds.scss
@@ -2,3 +2,4 @@
 @import "hds-core/lib/components/all";
 @import "hds-core/lib/icons/icon";
 @import "hds-core/lib/icons/icon-attention";
+@import "hds-core/lib/icons/icon-check";

--- a/sass/keycloak-overrides.scss
+++ b/sass/keycloak-overrides.scss
@@ -1,0 +1,72 @@
+@import 'theme';
+
+// Override the default background image with a solid color
+.login-pf {
+  background: $light-blue;
+}
+.login-pf body {
+  background: none;
+}
+
+// Use correct typography for page title
+#kc-page-title {
+  margin-top: 0;
+  margin-bottom: $spacing-layout-xs;
+
+  font-size: $font-size-2;
+  font-weight: bold;
+  text-align: unset;
+}
+
+// Use correct whitespace for login page
+.login-pf-page .card-pf {
+  padding: $spacing-layout-m;
+}
+
+.login-pf-page .login-pf-header {
+  margin-bottom: 0;
+}
+
+.card-pf {
+  max-width: 580px;
+}
+
+// Use correct whitespace for button container
+#kc-form-buttons {
+  margin-top: $spacing-layout-m;
+}
+
+// Unset text-align in order to ignore centered text
+.login-pf-page .login-pf-signup {
+  text-align: unset;
+}
+
+// Ignore margin that is used for inlined elements in original theme.
+// In the helsinki theme these elements are no longer inlined.
+.login-pf-page .login-pf-signup a {
+  margin-left: unset;
+}
+
+// Ignore margin that is used to separate form elements from info
+// elements
+.login-pf-page .login-pf-signup {
+  margin: unset;
+}
+
+// Ignore margin that breaks padding. It's on an element that should be 
+// the last element on pages. If it ends up not being that, set a margin
+// with &:not(:last-child).
+#kc-registration {
+  margin-bottom: unset;
+}
+
+// Set alert icon size to match that in design files
+.hds-notification .pficon {
+  position: relative;
+  bottom: -4px; // Center vertically
+  width: 24px;
+  height: 24px;
+  margin-right: $spacing-s;
+
+  font-size: 24px;
+}


### PR DESCRIPTION
- Adds inline errors to the registration form
- Fixes the icon that is used for checkbox (previously a html char was used)

<img width="597" alt="Screenshot 2020-04-29 at 14 51 27" src="https://user-images.githubusercontent.com/9090689/80592949-f9a6bb00-8a28-11ea-9f3c-aab7b47b5fb3.png">
<img width="597" alt="Screenshot 2020-04-29 at 14 51 42" src="https://user-images.githubusercontent.com/9090689/80592952-fb707e80-8a28-11ea-8802-66ca607644fd.png">
