### PR TITLE
OM-730 | Correctly style forgot password link

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.ftl]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/helsinki/login/login.ftl
+++ b/helsinki/login/login.ftl
@@ -45,8 +45,7 @@
 
                   <#if realm.resetPasswordAllowed>
                       <div id="hs-reset-password" class="${properties.kcFormGroupClass!}">
-                          <span class="${properties.hsSubtitle!}">${msg("forgotPassword")}</span>
-                          <a tabindex="4" class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" href="${url.loginResetCredentialsUrl}">${msg("doForgotPassword")}</a>
+                          <a tabindex="4" class="${properties.hsLinkClass!}" href="${url.loginResetCredentialsUrl}">${msg("forgotPassword")}</a>
                       </div>
                   </#if>
             </form>

--- a/helsinki/login/resources/js/customRegistrationValidation.js
+++ b/helsinki/login/resources/js/customRegistrationValidation.js
@@ -64,24 +64,37 @@
   // --> Handlers
 
   document.addEventListener("DOMContentLoaded", function (event) {
-    getRegistrationForm().addEventListener(
-      "submit",
-      handleRegistrationFormSubmit
-    );
-    getHsAcknowledgementsInput().addEventListener(
-      "change",
-      handleHsAcknowledgementsChange
-    );
+    var registrationForm = getRegistrationForm();
+    var hsAcknowledgementsInput = getHsAcknowledgementsInput();
+
+    if (registrationForm) {
+      registrationForm.addEventListener("submit", handleRegistrationFormSubmit);
+    }
+
+    if (hsAcknowledgementsInput) {
+      hsAcknowledgementsInput.addEventListener(
+        "change",
+        handleHsAcknowledgementsChange
+      );
+    }
   });
 
   window.onunload = function () {
-    getRegistrationForm().removeEventListener(
-      "submit",
-      handleRegistrationFormSubmit
-    );
-    getHsAcknowledgementsInput().removeEventListener(
-      "change",
-      handleHsAcknowledgementsChange
-    );
+    var registrationForm = getRegistrationForm();
+    var hsAcknowledgementsInput = getHsAcknowledgementsInput();
+
+    if (registrationForm) {
+      registrationForm.removeEventListener(
+        "submit",
+        handleRegistrationFormSubmit
+      );
+    }
+
+    if (hsAcknowledgementsInput) {
+      hsAcknowledgementsInput.removeEventListener(
+        "change",
+        handleHsAcknowledgementsChange
+      );
+    }
   };
 })();

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -30,6 +30,8 @@ hsInputwrapperClass=hs-input-wrapper
 hsIconClass=hds-icon
 hsAttentionIconClass=hds-icon--attention
 hsCheckIconClass=hds-icon--check
+# used for links
+hsLinkClass=hs-link
 
 ##### css classes for form buttons
 # main class used for all buttons

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -54,7 +54,7 @@ html {
 // Custom block 
 // On the login form that contains a password reset button.
 #hs-reset-password {
-  padding-bottom: $spacing-layout-s;
+  padding-bottom: $spacing-layout-xs;
   // Overrides default margin for form-group. This may end up being a
   // naive solution in the long run.
   margin-bottom: $spacing-s;
@@ -157,4 +157,23 @@ html {
 // Is used for positioning error icons
 .hs-input-wrapper {
   position: relative;
+}
+
+// Link
+.hs-link,
+a.hs-link {
+  padding-bottom: 1px;
+
+  font-size: $font-size-5;
+  font-weight: normal;
+  color: $color-primary;
+  text-decoration: none;
+
+  border-bottom: 1px solid currentColor;
+
+  &:hover {
+    color: $color-primary;
+
+    border-bottom-color: transparent;
+  }
 }

--- a/sass/keycloak-overrides.scss
+++ b/sass/keycloak-overrides.scss
@@ -34,6 +34,7 @@
 // Use correct whitespace for button container
 #kc-form-buttons {
   margin-top: $spacing-layout-m;
+  margin-bottom: $spacing-layout-xs;
 }
 
 // Unset text-align in order to ignore centered text


### PR DESCRIPTION
* Adds `.editorconfig`
* Fixes styles for forgot password link
* Fixes error caused by script assuming it could always find elements

<img width="600" alt="Screenshot 2020-04-30 at 8 16 37" src="https://user-images.githubusercontent.com/9090689/80674565-f2c88880-8aba-11ea-8376-fafdc220d470.png">
