### PR TITLE
OM-730 | Add styles for form feedback

### DIFF
--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -4,7 +4,7 @@ doRegister=Create a new Helsinki account
 doRegisterShort=Create account
 backToLogin=Cancel
 doAcknowledgeResources=I have read the privacy policy of the City of Helsinki
-emailSentMessage=You should receive an email shortly which will directly you to finish your registration/password reset.
+emailSentMessage=You should receive an email shortly which will direct you to finish your registration/password reset.
 
 # logo
 helsinkiLogo=helsinki-logo

--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -4,6 +4,7 @@ doRegister=Create a new Helsinki account
 doRegisterShort=Create account
 backToLogin=Cancel
 doAcknowledgeResources=I have read the privacy policy of the City of Helsinki
+emailSentMessage=You should receive an email shortly which will directly you to finish your registration/password reset.
 
 # logo
 helsinkiLogo=helsinki-logo

--- a/helsinki/login/template.ftl
+++ b/helsinki/login/template.ftl
@@ -113,12 +113,14 @@
           <#-- during login.                                                                               -->
           <#if showAlerts && displayMessage && message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
               <div class="${properties.hsAlertClass!}<#if message.type = 'success'> ${properties.hsAlertSuccessClass!}</#if><#if message.type = 'warning'> ${properties.hsAlertWarningClass!}</#if><#if message.type = 'error'> ${properties.hsAlertErrorClass!}</#if><#if message.type = 'info'> ${properties.hsAlertInfoClass!}</#if>">
-                  <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
-                  <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>
-                  <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
-                  <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
-                  <span class="${properties.hsAlertLabelClass!}">${kcSanitize(message.summary)?no_esc}</span>
-              </div>
+                <div class="${properties.hsAlertLabelClass!}">
+                    <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
+                    <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>
+                    <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
+                    <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
+                    ${kcSanitize(message.summary)?no_esc}
+                    </div>
+                </div>
           </#if>
 
           <#nested "form">

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -62,3 +62,8 @@ kcFormOptionsClass=
 kcFormButtonsClass=hs-button-row
 # class that sets a form group into error state
 kcFormGroupErrorClass=hs-has-error
+# feddback icons
+kcFeedbackSuccessIcon=hds-icon hds-icon--attention
+kcFeedbackWarningIcon=
+kcFeedbackErrorIcon=hds-icon hds-icon--attention
+kcFeedbackInfoIcon=

--- a/sass/hds-overrides.scss
+++ b/sass/hds-overrides.scss
@@ -90,13 +90,23 @@ a.hds-button--supplementary {
 .hds-notification {
   padding: $spacing-s;
 
-  background-color: $color-error-light;
   border-left-width: 0.25rem;
-  border-color: $color-error;
+  
+  &--error {
+    color: $color-error;
+
+    background-color: $color-error-light;
+    border-color: $color-error;
+  }
+
+  &--success {
+    color: #007293;
+
+    background-color: $color-info-light;
+    border-color: #007293;
+  }
 }
 .hds-notification__label {
-  // This colour was in the design file, but it does not exists in HDS.
-  color: $color-error;
   font-size: $font-size-5;
   font-weight: bold;
 }


### PR DESCRIPTION
Originally these notifications were meant to be replaced with new views, e.g.

<img width="557" alt="Screenshot 2020-05-04 at 7 50 00" src="https://user-images.githubusercontent.com/9090689/80936984-eeaeaa80-8ddb-11ea-932f-2813301693fd.png">

But I couldn't find any default template variables which would allow me to deduce when we've last visited the password reset view. So, instead of a view, we'll stick to the notifications keycloak has by default.

Because keycloak has a single generic message for all sent emails (at least password reset and account creation), we've had to replace the original string with one that takes this into account.

<img width="597" alt="Screenshot 2020-05-04 at 7 57 24" src="https://user-images.githubusercontent.com/9090689/80937243-00dd1880-8ddd-11ea-8a3a-b60e1bb0845e.png">
