### PR TITLE
OM-730 | Various fixes

### DIFF
--- a/helsinki/login/login-update-password.ftl
+++ b/helsinki/login/login-update-password.ftl
@@ -1,0 +1,45 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayInfo=true showWarnings=false; section>
+    <#if section = "header">
+        ${msg("updatePasswordTitle")}
+    <#elseif section = "form">
+        <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
+            <input type="text" id="username" name="username" value="${username}" autocomplete="username" readonly="readonly" style="display:none;"/>
+            <input type="password" id="password" name="password" autocomplete="current-password" style="display:none;"/>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="password-new" class="${properties.kcLabelClass!}">${msg("passwordNew")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="password" id="password-new" name="password-new" class="${properties.kcInputClass!}" autofocus autocomplete="new-password" />
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="password-confirm" class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
+                </div>
+                <div class="${properties.kcInputWrapperClass!}">
+                    <input type="password" id="password-confirm" name="password-confirm" class="${properties.kcInputClass!}" autocomplete="new-password" />
+                </div>
+            </div>
+
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <#if isAppInitiatedAction??>
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}" />
+                    <button class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" type="submit" name="cancel-aia" value="true" />${msg("doCancel")}</button>
+                    <#else>
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doSubmit")}" />
+                    </#if>
+                </div>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/helsinki/login/login-verify-email.ftl
+++ b/helsinki/login/login-verify-email.ftl
@@ -2,7 +2,5 @@
 <@layout.registrationLayout; section>
     <#if section = "header">
         ${msg("emailVerifyTitle")}
-    <#elseif section = "form">
-        <a class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" href="${url.loginAction}">${msg("doCreateNewConfirmationLink")}</a>
     </#if>
 </@layout.registrationLayout>

--- a/helsinki/login/template.ftl
+++ b/helsinki/login/template.ftl
@@ -1,4 +1,4 @@
-<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false displayWide=false showAnotherWayIfPresent=true showAlerts=true>
+<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false displayWide=false showAnotherWayIfPresent=true showAlerts=true showWarnings=true>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" class="${properties.kcHtmlClass!}">
 
@@ -112,7 +112,11 @@
           <#-- App-initiated actions should not see warning messages about the need to complete the action -->
           <#-- during login.                                                                               -->
           <#if showAlerts && displayMessage && message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
-            <#if message.type = 'warning'>
+            <#-- HS: Some views have warning messages which are styled as regular paragraphs in this theme. -->
+            <#-- When you downgrade some of the warnings messages into regular paragraphs, you end up with repeating content. -->
+            <#-- This flag allows us to toggle off those warning messages on a template-to-template basis. -->
+            <#if message.type = 'warning' && !showWarnings>
+            <#elseif message.type = 'warning' && showWarnings>
                 <p class="${properties.hsPClass}">${kcSanitize(message.summary)?no_esc}</p>
             <#else>
               <div class="${properties.hsAlertClass!}<#if message.type = 'success'> ${properties.hsAlertSuccessClass!}</#if><#if message.type = 'warning'> ${properties.hsAlertWarningClass!}</#if><#if message.type = 'error'> ${properties.hsAlertErrorClass!}</#if><#if message.type = 'info'> ${properties.hsAlertInfoClass!}</#if>">

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -183,9 +183,11 @@ a.hs-link {
 // styles
 .hs-p,
 .login-pf-page .card-pf .hs-p {
-  margin-bottom: $spacing-m;
-
   font-size: $font-size-5;
   color: $color-black-90;
   line-height: 1.5;
+
+  &:not(:last-child) {
+    margin-bottom: $spacing-m;
+  }
 }

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -77,11 +77,24 @@ html {
 
 // Custom button wrapper
 // A wrapping block element that positions two button side by side with
-// margin in between.
+// margin in between or a single button spanning entire row.
 .hs-button-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-column-gap: $spacing-xs;
+  display: flex;
+
+  // When flexbox begins to support column-gap, we can replace the below
+  // rules with column-gap: $spacing-xs;
+  & *:first-child {
+    margin-right: $spacing-xs / 2;
+  }
+
+  & *:last-child {
+    margin-left: $spacing-xs / 2;
+  }
+
+  // If the button is alone, apply no margin.
+  & *:only-child {
+    margin: 0;
+  }
 }
 
 // Custom checkbox component copied from open-city-profile
@@ -183,6 +196,8 @@ a.hs-link {
 // styles
 .hs-p,
 .login-pf-page .card-pf .hs-p {
+  margin-bottom: 0;
+
   font-size: $font-size-5;
   color: $color-black-90;
   line-height: 1.5;

--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -174,7 +174,8 @@ html {
 
 // Link
 .hs-link,
-a.hs-link {
+a.hs-link,
+a {
   padding-bottom: 1px;
 
   font-size: $font-size-5;

--- a/sass/hds-overrides.scss
+++ b/sass/hds-overrides.scss
@@ -66,6 +66,8 @@ a.hds-button {
   font-size: $font-size-body-default;
   font-weight: 600;
   line-height: 1.625;
+  // Required for input[type="submit"] on Firefox
+  text-align: center;
 }
 
 .hds-button--primary,

--- a/sass/keycloak-overrides.scss
+++ b/sass/keycloak-overrides.scss
@@ -1,4 +1,5 @@
 @import 'theme';
+@import 'custom';
 
 // Override the default background image with a solid color
 .login-pf {
@@ -73,4 +74,23 @@
   margin-right: $spacing-s;
 
   font-size: 24px;
+}
+
+// Use hs-p style for instructions
+.instruction {
+  @extend .hs-p;
+}
+
+// Remove bottom border that is applied by custom a rules
+#kc-current-locale-link {
+  border-bottom: none;
+}
+#kc-locale ul li a {
+  border-bottom: none;
+}
+
+// Resolve keycloak link styles that conflict with hs styles
+.login-pf a:hover {
+  color: $color-primary;
+  text-decoration: none;
 }


### PR DESCRIPTION
* Removes email resend button from verify email template
* Generally targets `a` and `p` elements with theme specific styles
* Fixes left aligned `input[type="button"]` on Firefox
* Removes description from password update page that repeated content