### PR TITLE
HP-108 | Hide errors when user focuses input

### DIFF
--- a/helsinki/login/resources/js/inputReset.js
+++ b/helsinki/login/resources/js/inputReset.js
@@ -1,0 +1,63 @@
+(function () {
+  // <-- Constants
+  var HS_INPUT_CONTAINER_CLASS = "hds-text-input--invalid";
+  var HS_INPUT_CONTAINER_ERROR_CLASS = "hds-text-input--invalid";
+  var HS_INPUT_CLASS = "hds-text-input__input";
+  var HS_INPUT_TEXT_CLASS = "hds-text-input__helper-text";
+  // --> Constants
+
+  // <-- Selectors
+  function getErrorInputs() {
+    return document.querySelectorAll(
+      "." + HS_INPUT_CONTAINER_ERROR_CLASS + " ." + HS_INPUT_CLASS
+    );
+  }
+  function getInputContainerByInput(input) {
+    return input.closest("." + HS_INPUT_CONTAINER_CLASS);
+  }
+  function getErrorTextByInput(input) {
+    return getInputContainerByInput(input).querySelector(
+      "." + HS_INPUT_TEXT_CLASS
+    );
+  }
+  // --> Selectors
+
+  // <-- Handlers
+  var handleErrorInputFocus = function (event) {
+    var errorInput = event.target;
+    var errorInputContainer = getInputContainerByInput(errorInput);
+    var errorText = getErrorTextByInput(errorInput);
+
+    if (errorInputContainer) {
+      errorInputContainer.classList.remove(HS_INPUT_CONTAINER_ERROR_CLASS);
+    }
+
+    if (errorText) {
+      errorText.remove();
+    }
+  };
+  // --> Handlers
+
+  document.addEventListener("DOMContentLoaded", function (event) {
+    var errorInputs = getErrorInputs();
+
+    errorInputs.forEach((errorInput) => {
+      errorInput.addEventListener("focusin", handleErrorInputFocus, {
+        once: true,
+      });
+    });
+  });
+
+  window.onunload = function () {
+    // If there are remaining errors, clean up their event listeners.
+    // Not sure if it's possible to end up a situation where this can
+    // happen.
+    var errorInputs = getErrorInputs();
+
+    if (errorInputs) {
+      errorInputs.forEach((errorInput) => {
+        errorInput.removeEventListener("focusin", handleErrorInputFocus);
+      });
+    }
+  };
+})();

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -5,7 +5,7 @@ import=common/keycloak
 styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/helsinki-grotesk.css css/hds.css css/keycloak-overrides.css css/hds-overrides.css css/custom.css
 
 # Add custom JS hooks
-scripts=js/customRegistrationValidation.js
+scripts=js/customRegistrationValidation.js js/inputReset.js
 
 # Custom property that can be used to hide the header
 showHeader=false


### PR DESCRIPTION
If the user submits a form with inline errors (registration form) with incorrect inputs, errors will be rendered in conjunction with those inputs that have incorrect data. Previously these errors were retained until the user submitted the form again.

After these changes, the errors will be hidden once the user focuses an erroneous input.