### PR TITLE
HP-108 | Improve UX on mobile

### DIFF
--- a/sass/custom.scss
+++ b/sass/custom.scss
@@ -78,22 +78,41 @@ html {
 // Custom button wrapper
 // A wrapping block element that positions two button side by side with
 // margin in between or a single button spanning entire row.
+//
+// On mobile buttons will appear in a column in the reversed order--the
+// latter button is displayed first.
 .hs-button-row {
   display: flex;
+  flex-direction: column-reverse;
 
-  // When flexbox begins to support column-gap, we can replace the below
-  // rules with column-gap: $spacing-xs;
-  & *:first-child {
-    margin-right: $spacing-xs / 2;
+  // Logic is reversed because the order is reversed. Normally we would
+  // disabled margin for the last item.
+  & *:not(:first-child) {
+    margin-bottom: $spacing-xs;
   }
 
-  & *:last-child {
-    margin-left: $spacing-xs / 2;
-  }
+  @media (min-width: $breakpoint-tablet) {  
+    flex-direction: row;
 
-  // If the button is alone, apply no margin.
-  & *:only-child {
-    margin: 0;
+    // Remove bottom margin on non-mobile layout
+    & *:not(:first-child) {
+      margin-bottom: unset;
+    }
+
+    // When flexbox begins to support column-gap, we can replace the below
+    // rules with column-gap: $spacing-xs;
+    & *:first-child {
+      margin-right: $spacing-xs / 2;
+    }
+
+    & *:last-child {
+      margin-left: $spacing-xs / 2;
+    }
+
+    // If the button is alone, apply no margin.
+    & *:only-child {
+      margin: 0;
+    }
   }
 }
 

--- a/sass/keycloak-overrides.scss
+++ b/sass/keycloak-overrides.scss
@@ -19,9 +19,20 @@
   text-align: unset;
 }
 
+// Ignore top padding on mobile views.
+.login-pf-page {
+  @media (max-width: $breakpoint-tablet) {
+    padding-top: 0;
+  }
+}
+
 // Use correct whitespace for login page
 .login-pf-page .card-pf {
-  padding: $spacing-layout-m;
+  padding: $spacing-layout-xs;
+
+  @media (min-width: $breakpoint-tablet) {
+    padding: $spacing-layout-m;
+  }
 }
 
 .login-pf-page .login-pf-header {

--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -14,3 +14,6 @@ $font-family-base: $hel-grotesk;
 $page-background: $color-fog;
 $color-primary: $color-bus;
 $color-primary-dark: $color-bus-dark-50;
+
+// Breakpoints
+$breakpoint-tablet: 768px;


### PR DESCRIPTION
Decreases padding for the containing element and arranges button rows as columns instead.

<img width="637" alt="Screenshot 2020-05-14 at 17 13 22" src="https://user-images.githubusercontent.com/9090689/81945274-927f2e00-9606-11ea-8a63-1eaa5dd341e2.png">
<img width="346" alt="Screenshot 2020-05-14 at 17 13 56" src="https://user-images.githubusercontent.com/9090689/81945279-9448f180-9606-11ea-82b9-4807e902345c.png">
