### PR TITLE
Fix sign out not working in test server

### DIFF
--- a/helsinki/account/theme.properties
+++ b/helsinki/account/theme.properties
@@ -6,7 +6,7 @@ locales=en,sv,fi
 styles=node_modules/patternfly/dist/css/patternfly.min.css node_modules/patternfly/dist/css/patternfly-additions.min.css css/account.css css/hds.css css/shared.css css/hs-account.css
 
 # Add custom JS hooks
-scripts=js/fakeSignoutPage.js
+scripts=js/fakeSignOutPage.js
 
 ### Custom settings
 # By default keycloak always shows UI elements that label required


### PR DESCRIPTION
Locally the case didn't matter, but on the server it results in an not
found error.