### PR TITLE
Fix missing email already exists error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix language menu breaking page whitespace
 - Fix password fields showing typed passwords in account page
 - Fix missing errors on account password change page
+- Fix missing email already in use error on the account page

--- a/helsinki/account/account.ftl
+++ b/helsinki/account/account.ftl
@@ -1,5 +1,12 @@
 <#import "template.ftl" as layout>
 <@layout.mainLayout active='account' bodyClass='user' showErrors=true; section>
+<!-- For some reason, in this view, the error a user receives when -->
+<!-- trying to change their email to one that's already attached to -->
+<!-- an account, is not  a field level error, but a "global error". -->
+<!-- This behaviour is different compared to the registration form. -->
+<!-- For this reason, we can't omit the messages element from the -->
+<!-- account editing page. For now, errors are shown twice in the -->
+<!-- view. Once on top and once inline. -->
 
     <#if section = "header">
         ${msg("editAccountHtmlTitle")}

--- a/helsinki/account/account.ftl
+++ b/helsinki/account/account.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.mainLayout active='account' bodyClass='user' showErrors=false; section>
+<@layout.mainLayout active='account' bodyClass='user' showErrors=true; section>
 
     <#if section = "header">
         ${msg("editAccountHtmlTitle")}


### PR DESCRIPTION
For some reason, in this view, the error a user receives when trying to
change their email to one that's already attached to an account, is not
a field level error, but a "global error". This behaviour is different
compared to the registration form. For this reason, we can't omit the
messages element from the account editing page.

For now, errors are shown twice in the view. I checked with the
assigned designer that this was the behaviour we preferred.