### PR TITLE
HP-9: Fix link to reset password

### DIFF
--- a/helsinki/email/messages/messages_en.properties
+++ b/helsinki/email/messages/messages_en.properties
@@ -3,8 +3,8 @@ emailVerificationSubject = Verify email
 emailVerificationBody = Someone has created a Helsinki account with this email address. If this was you, click the link below to verify your email address\n\n{0}\n\nThis link will expire within {3}.\n\nIf you didn''t create this account, just ignore this message.
 emailVerificationBodyHtml = <p>Someone has created a Helsinki account with this email address. If this was you, click the link below to verify your email address</p><p><a href={0}">Link to e-mail address verification</a></p><p>This link will expire within {3}.</p><p>If you didn''t create this account, just ignore this message.</p>
 passwordResetSubject = Reset password
-passwordResetBody = Someone just requested to change your Helsinki account's password. If this was you, click on the link below to reset it.\n\n{0}\n\nThis link and code will expire within {3}.\n\nIf you don''t want to reset your password, just ignore this message and nothing will be changed.
-passwordResetBodyHtml = <p>Someone just requested to change your Helsinki account's password. If this was you, click on the link below to reset it.</p><p><a href={0}">Link to reset password</a></p><p>This link will expire within {3}.</p><p>If you don''t want to reset your password, just ignore this message and nothing will be changed.</p>
+passwordResetBody = Someone just requested to change your Helsinki account''s password. If this was you, click on the link below to reset it.\n\n{0}\n\nThis link and code will expire within {3}.\n\nIf you don''t want to reset your password, just ignore this message and nothing will be changed.
+passwordResetBodyHtml = <p>Someone just requested to change your Helsinki account''s password. If this was you, click on the link below to reset it.</p><p><a href={0}">Link to reset password</a></p><p>This link will expire within {3}.</p><p>If you don''t want to reset your password, just ignore this message and nothing will be changed.</p>
 linkExpirationFormatter.timePeriodUnit.seconds = seconds
 linkExpirationFormatter.timePeriodUnit.seconds.1 = second
 linkExpirationFormatter.timePeriodUnit.minutes = minutes

--- a/helsinki/email/messages/messages_fi.properties
+++ b/helsinki/email/messages/messages_fi.properties
@@ -4,7 +4,7 @@ emailVerificationBody = Joku on luonut tälle sähköpostiosoitteelle Helsinki-t
 emailVerificationBodyHtml = <p>Joku on luonut tälle sähköpostiosoitteelle Helsinki-tunnuksen. Jos se olit sinä, niin vahvista tunnus alla olevan linkin avulla.</p><p><a href={0}">Vahvista sähköpostiosoite</a></p><p>Tämä linki on voimassa {3}.</p><p>Jos et ole pyytänyt Helsinki-tunnuksen luomista itsellesi, voit jättää tämän viestin huomiotta.</p>
 passwordResetSubject = Vaihda salasana
 passwordResetBody = Saimme pyynnön muuttaa Helsinki-tunnuksesi salasanan. Jos pyysit salasanan muuttamista, pääset tekemään sen tällä linkillä.\n\n{0}\n\nTämä linkki on voimassa {3}.\n\nJos et halua muuttaa salasanaasi tai et ole pyytänyt salasanan muuttamista itse, voit jättää tämän viestin huomiotta ja jatkaa tunnuksesi käyttöä.
-passwordResetBodyHtml = <p>Saimme pyynnön muuttaa Helsinki-tunnuksesi salasanan. Jos pyysit salasanan muuttamista, pääset tekemään sen tällä linkillä.</p><p><a href={0}">Muuta salasana</a></p><p>Tämä linnki on voimassa {3}.</p><p>Jos et halua muuttaa salasanaasi tai et ole pyytänyt salasanan vaihtoa itse, voit jättää tämän viestin huomiotta ja jatkaa tunnuksesi käyttöä.</p>
+passwordResetBodyHtml = <p>Saimme pyynnön muuttaa Helsinki-tunnuksesi salasanan. Jos pyysit salasanan muuttamista, pääset tekemään sen tällä linkillä.</p><p><a href={0}">Muuta salasana</a></p><p>Tämä linkki on voimassa {3}.</p><p>Jos et halua muuttaa salasanaasi tai et ole pyytänyt salasanan vaihtoa itse, voit jättää tämän viestin huomiotta ja jatkaa tunnuksesi käyttöä.</p>
 linkExpirationFormatter.timePeriodUnit.seconds = sekuntia
 linkExpirationFormatter.timePeriodUnit.seconds.1 = sekunnin
 linkExpirationFormatter.timePeriodUnit.minutes = minuuttia


### PR DESCRIPTION
Fixed typos in the email templates which caused reset password link not to render when language is English.

Fixed also another typo in the Finnish template.