### PR TITLE
HP-865 make form ids unique

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # helsinki-keycloak-theme
+
 Helsinki theme for Keycloaks IAM
 
-**Requirements**  
+**Requirements**
+
 - npm
 - node
 
@@ -18,6 +20,7 @@ Helsinki theme for Keycloaks IAM
 To test this theme 1. Set up your local environment and then 2. build the theme.
 
 **Table of Contents**
+
 1. [Setting up a local environment](#setting-up-a-local-environment)
 1. [Building the theme](#building-the-theme)
 1. [Translations](#translations)
@@ -26,36 +29,37 @@ To test this theme 1. Set up your local environment and then 2. build the theme.
 
 ## Setting up a local environment
 
-**1. Clone this repository**  
+**1. Clone this repository**
+
 ```
 git clone https://github.com/City-of-Helsinki/helsinki-keycloak-theme.git
 ```
 
-**2. Obtain a local keycloak instance**  
+**2. Obtain a local keycloak instance**
 
 Find instructions here:
 https://www.keycloak.org/docs/latest/getting_started/
 
 Please also create an account for yourself.
 
-**3. Create a new realm**  
+**3. Create a new realm**
 
 For instance with the name of `locale-dev`
 
-**4. Change login settings for your new realm**  
+**4. Change login settings for your new realm**
 
 New Realm > Realm Settings > Login
 
-| Setting | Value |
-|:-|:-|
-| User registration | true |
-| Email as username  | true |
-| Edit username | false |
-| Forgot password | true |
-| Remember me | false |
-| Verify email | false |
-| Login with email | true |
-| Require SSL | external request |
+| Setting           | Value            |
+| :---------------- | :--------------- |
+| User registration | true             |
+| Email as username | true             |
+| Edit username     | false            |
+| Forgot password   | true             |
+| Remember me       | false            |
+| Verify email      | false            |
+| Login with email  | true             |
+| Require SSL       | external request |
 
 New Realm > Realm Settings > Email
 
@@ -63,7 +67,7 @@ _Example settings for gmail with only the set settings as listed_
 | Setting | Value |
 |:-|:-|
 | Host | smtp.gmail.com |
-| Port  | 465 |
+| Port | 465 |
 | From Display Name | local-dev-keycloak |
 | From | local-dev-keycloak@somemail.com |
 | Enable SSL | true |
@@ -71,8 +75,7 @@ _Example settings for gmail with only the set settings as listed_
 | Username | your-gmail-username |
 | Password | your-gmail-password |
 
-
-**5. Disable caching for themes**  
+**5. Disable caching for themes**
 
 `<Keycloak folder>/standalone/configuration/standalone.xml`
 
@@ -86,7 +89,7 @@ _Example settings for gmail with only the set settings as listed_
 +    <cacheTemplates>false</cacheTemplates>
 ```
 
-**6. Symlink helsinki theme into theme folder**  
+**6. Symlink helsinki theme into theme folder**
 
 When you are in `<Keycloak folder>/themes`
 
@@ -94,12 +97,12 @@ When you are in `<Keycloak folder>/themes`
 ln -s ~/path/to/helsinki-keycloak-theme/helsinki
 ```
 
-**7. Use helsinki theme**  
+**7. Use helsinki theme**
 
 New Realm > Realm Settings > Theme
 
-| Setting | Value |
-|:-|:-|
+| Setting     | Value    |
+| :---------- | :------- |
 | Login Theme | helsinki |
 
 ## Building the theme
@@ -110,7 +113,7 @@ First, install `npm` dependencies
 npm install
 ```
 
-Then, build the project 
+Then, build the project
 
 ```bash
 npm run build
@@ -161,11 +164,13 @@ Developing theme while running local instance of helsinki-tunnistus docker image
 First, run the image with instructions in helsinki-tunnistus repo.
 
 Second, bypass the cache. Keycloak caches js and HTML. Settings are in keycloak server's folder. Copy it to your local machine:
+
 ```bash
 docker cp keycloak_test:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml /tmp
 ```
 
 Change following nodes:
+
 ```xml
 <staticMaxAge>-1</staticMaxAge>
 <cacheThemes>false</cacheThemes>
@@ -173,16 +178,19 @@ Change following nodes:
 ```
 
 Copy file back to docker container:
+
 ```bash
 docker cp /tmp/standalone-ha.xml keycloak_test:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml
 ```
 
 Copy your theme to docker container
+
 ```bash
 docker cp /local-path-to-theme/helsinki-keycloak-theme/helsinki/. keycloak_test:/opt/jboss/keycloak/themes/helsinki
 ```
 
 Restart the container. It takes about a 30-60 seconds to get the server back online.
+
 ```bash
 docker restart keycloak_test
 ```
@@ -194,5 +202,4 @@ docker exec -it keycloak_test /bin/bash
 /opt/jboss/keycloak/bin/./jboss-cli.sh --connect command=:reload
 ```
 
-Theme must be copied and docker restarted after every change. 
-
+Theme must be copied and docker restarted after every change.

--- a/README.md
+++ b/README.md
@@ -158,15 +158,11 @@ It's recommended to configure your development environment in a way where errors
 
 Developing theme while running local instance of helsinki-tunnistus docker image is not very convenient.
 
-First, run the image with instructions in helsinki-tunnistus repo. Get the container id with 
-```bash
-docker ps
-```
-This example uses `abcdef123`
+First, run the image with instructions in helsinki-tunnistus repo.
 
 Second, bypass the cache. Keycloak caches js and HTML. Settings are in keycloak server's folder. Copy it to your local machine:
 ```bash
-docker cp abcdef123:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml /tmp
+docker cp keycloak_test:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml /tmp
 ```
 
 Change following nodes:
@@ -178,17 +174,24 @@ Change following nodes:
 
 Copy file back to docker container:
 ```bash
-docker cp /tmp/standalone-ha.xml abcdef123:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml
+docker cp /tmp/standalone-ha.xml keycloak_test:/opt/jboss/keycloak/standalone/configuration/standalone-ha.xml
 ```
 
 Copy your theme to docker container
 ```bash
-docker cp /local-path-to-theme/helsinki-keycloak-theme/helsinki/. abcdef123:/opt/jboss/keycloak/themes/helsinki
+docker cp /local-path-to-theme/helsinki-keycloak-theme/helsinki/. keycloak_test:/opt/jboss/keycloak/themes/helsinki
 ```
 
 Restart the container. It takes about a 30-60 seconds to get the server back online.
 ```bash
-docker restart abcdef123
+docker restart keycloak_test
+```
+
+Or restart the server inside the container.
+
+```bash
+docker exec -it keycloak_test /bin/bash
+/opt/jboss/keycloak/bin/./jboss-cli.sh --connect command=:reload
 ```
 
 Theme must be copied and docker restarted after every change. 

--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -10,7 +10,7 @@
             </div>
         </div>
 
-        <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
+        <form id="kc-custom-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">
             <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('firstName',properties.kcFormGroupErrorClass!)}">
                 <div class="${properties.kcLabelWrapperClass!}">
                     <label for="firstName" class="${properties.kcLabelClass!}">${msg("firstName")}</label>

--- a/helsinki/login/resources/css/hs-login.css
+++ b/helsinki/login/resources/css/hs-login.css
@@ -198,7 +198,7 @@ a {
       top: 6rem;
       right: 3rem; } }
 
-#kc-register-form .hs-form-group:not(:last-child) {
+#kc-custom-register-form .hs-form-group:not(:last-child) {
   margin-bottom: 1.5rem; }
 
 #hs-reset-password {

--- a/helsinki/login/resources/js/customRegistrationValidation.js
+++ b/helsinki/login/resources/js/customRegistrationValidation.js
@@ -1,7 +1,7 @@
 (function () {
   // <-- Constants
   var HS_HAS_ERROR_CLASS = "hs-has-error";
-  var KC_REGISTER_FORM_ID = "kc-register-form";
+  var KC_REGISTER_FORM_ID = "kc-custom-register-form";
   var HS_ACKNOWLEDGEMENTS_FORM_GROUP_ID = "hs-acknowledgements-form-group";
   var HS_ACKNOWLEDGEMENTS_INPUT_ID = "hs-acknowledgements";
   var HS_AGE_CHECK_FORM_GROUP_ID = "hs-age-check-form-group";

--- a/helsinki/login/resources/js/profileCreationValidation.js
+++ b/helsinki/login/resources/js/profileCreationValidation.js
@@ -2,15 +2,15 @@
   // <-- Constants
   // match following class with kcFormGroupHasErrorClass in login/theme.properties
   var HS_HAS_ERROR_CLASS = "hs-has-error";
-  var KC_CREATE_PROFILE_FORM_ID = "kc-create-profile-form";
-  var KC_UPDATE_PROFILE_FORM_ID = "kc-update-profile-form";
+  var KC_SAVE_PROFILE_CONFIRM_FORM_ID = "kc-save-profile-confirm-form";
+  var KC_UPDATE_PROFILE_CONFIRM_FORM_ID = "kc-update-profile-confirm-form";
   var HS_ACKNOWLEDGEMENTS_INPUT_ID = "hs-acknowledgements";
   var HS_ACKNOWLEDGEMENTS_FORM_GROUP_ID = "hs-acknowledgements-form-group";
   var SUBMIT_BUTTONS_SELECTOR =
     "#" +
-    KC_CREATE_PROFILE_FORM_ID +
+    KC_SAVE_PROFILE_CONFIRM_FORM_ID +
     " button, #" +
-    KC_UPDATE_PROFILE_FORM_ID +
+    KC_UPDATE_PROFILE_CONFIRM_FORM_ID +
     " button";
   var RESPONSE_INPUT_ID = "kc-response";
   var HS_EMAIL_INPUT_ID = "hs-email";
@@ -45,7 +45,7 @@
   // <-- Selectors
 
   function getCreateProfileForm() {
-    return document.getElementById(KC_CREATE_PROFILE_FORM_ID);
+    return document.getElementById(KC_SAVE_PROFILE_CONFIRM_FORM_ID);
   }
 
   function getHsAcknowledgementsFormGroup() {
@@ -73,7 +73,7 @@
   }
 
   function getUpdateProfileForm() {
-    return document.getElementById(KC_UPDATE_PROFILE_FORM_ID);
+    return document.getElementById(KC_UPDATE_PROFILE_CONFIRM_FORM_ID);
   }
 
   // --> Selectors

--- a/helsinki/login/save-profile-confirm-dialog.ftl
+++ b/helsinki/login/save-profile-confirm-dialog.ftl
@@ -45,7 +45,7 @@
         <span class="hs-side-note">${msg("securitySideNote")}</span>
       </#if>
 		</div>
-		<form class="form-actions" id="kc-create-profile-form" action="${url.loginAction}" method="post">
+		<form class="form-actions" id="kc-save-profile-confirm-form" action="${url.loginAction}" method="post">
       <div id="hs-email-form-group" class="${properties.kcFormGroupClass!} ${emailErrorClassname}">
         <div class="hds-text-input" id="hs-email-form-group" class="${properties.kcFormGroupClass!}">
             <label class="hds-text-input__label" for="hs-email">${msg("emailLabel")}</label>

--- a/helsinki/login/update-profile-confirm-dialog.ftl
+++ b/helsinki/login/update-profile-confirm-dialog.ftl
@@ -6,7 +6,7 @@
 		<div id="kc-terms-text">
       <p>${msg("updateProfileText")?no_esc}</p>
 		</div>
-		<form class="form-actions" id="kc-update-profile-form" action="${url.loginAction}" method="post">
+		<form class="form-actions" id="kc-update-profile-confirm-form" action="${url.loginAction}" method="post">
       <div class="wide-buttons">
 			  <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" id="kc-accept" type="button" value="accept">${msg("updateProfileSubmitLabel")}</button>
         <input type="hidden" name="response" id="kc-response" value="" />

--- a/sass/login/custom.scss
+++ b/sass/login/custom.scss
@@ -4,7 +4,7 @@
 // has used a smaller spacing for it. Most forms in this app are short
 // so we are treating the condensed form as a special case.
 
-#kc-register-form .hs-form-group {
+#kc-custom-register-form .hs-form-group {
   &:not(:last-child) {
     margin-bottom: $spacing-layout-xs;
   }


### PR DESCRIPTION
Forms whose ids are used in javascript to handle submitting, validation, etc must have element ids that are not same as in the base theme. Otherwise forms that are not in overwritten in Helsinki theme might not work because js-files are anyway added to the HTML output.

Changed element ids that are used in js-files and are same in Helsinki theme and base theme.    