### PR TITLE
HP-914: email verification form

### DIFF
--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -91,3 +91,7 @@ updateProfileSubmitLabel = EN: Selvä homma, jatkan palveluun
 plainEmailFormTitle = EN: Sähköpostiosoitteesi
 plainEmailFormText = EN: Sähköpostiosoitteesi on sisäänkirjautumistunnuksesi ja Helsingin kaupunki käyttää sitä asiointiin liittyvään viestintään.
 continue = Continue
+verificationCodeFormTitle = EN: Vahvista sähköpostiosoite
+verificationCodeFormText = EN: Olemme lähettäneet sähköpostiosoitteeseesi vahvistuskoodin. Sähköpostiosoitteesi toimii myös sisäänkirjautumistunnuksena, joten et voi kirjautua sisään jos et ole vahvistanut tunnustasi. Jos et saanut viestiä, tarkasta myös sähköpostin roskaposti-kansio.
+verificationCodeFormError = EN: Antamasi vahvistuskoodi on virheellinen
+verificationCodeFormLabel = Verification Code

--- a/helsinki/login/messages/messages_fi.properties
+++ b/helsinki/login/messages/messages_fi.properties
@@ -91,3 +91,7 @@ updateProfileSubmitLabel = Selvä homma, jatkan palveluun
 plainEmailFormTitle = Sähköpostiosoitteesi
 plainEmailFormText = Sähköpostiosoitteesi on sisäänkirjautumistunnuksesi ja Helsingin kaupunki käyttää sitä asiointiin liittyvään viestintään.
 continue = Jatka
+verificationCodeFormTitle = Vahvista sähköpostiosoite
+verificationCodeFormText = Olemme lähettäneet sähköpostiosoitteeseesi vahvistuskoodin. Sähköpostiosoitteesi toimii myös sisäänkirjautumistunnuksena, joten et voi kirjautua sisään jos et ole vahvistanut tunnustasi. Jos et saanut viestiä, tarkasta myös sähköpostin roskaposti-kansio.
+verificationCodeFormError = Antamasi vahvistuskoodi on virheellinen
+verificationCodeFormLabel = Vahvistuskoodi

--- a/helsinki/login/messages/messages_sv.properties
+++ b/helsinki/login/messages/messages_sv.properties
@@ -91,3 +91,7 @@ updateProfileSubmitLabel = SV: Selvä homma, jatkan palveluun
 plainEmailFormTitle = SV: Sähköpostiosoitteesi
 plainEmailFormText = SV: Sähköpostiosoitteesi on sisäänkirjautumistunnuksesi ja Helsingin kaupunki käyttää sitä asiointiin liittyvään viestintään.
 continue = SV: Jatka
+verificationCodeFormTitle = SV: Vahvista sähköpostiosoite
+verificationCodeFormText = SV: Olemme lähettäneet sähköpostiosoitteeseesi vahvistuskoodin. Sähköpostiosoitteesi toimii myös sisäänkirjautumistunnuksena, joten et voi kirjautua sisään jos et ole vahvistanut tunnustasi. Jos et saanut viestiä, tarkasta myös sähköpostin roskaposti-kansio.
+verificationCodeFormError = SV: Antamasi vahvistuskoodi on virheellinen
+verificationCodeFormLabel = SV: Vahvistuskoodi

--- a/helsinki/login/resources/js/profileCreationValidation.js
+++ b/helsinki/login/resources/js/profileCreationValidation.js
@@ -5,6 +5,7 @@
   var KC_SAVE_PROFILE_CONFIRM_FORM_ID = "kc-save-profile-confirm-form";
   var KC_UPDATE_PROFILE_CONFIRM_FORM_ID = "kc-update-profile-confirm-form";
   var KC_PROVIDE_PLAIN_EMAIL_FORM_ID = "kc-provide-plain-email-form";
+  var KC_EMAIL_VERIFICATION_CODE_FORM_ID = "kc-email-verification-code-form";
   var HS_ACKNOWLEDGEMENTS_INPUT_ID = "hs-acknowledgements";
   var HS_ACKNOWLEDGEMENTS_FORM_GROUP_ID = "hs-acknowledgements-form-group";
   var SUBMIT_BUTTONS_SELECTOR =
@@ -14,9 +15,12 @@
     KC_UPDATE_PROFILE_CONFIRM_FORM_ID +
     " button, #" +
     KC_PROVIDE_PLAIN_EMAIL_FORM_ID +
+    " button, #" +
+    KC_EMAIL_VERIFICATION_CODE_FORM_ID +
     " button";
   var RESPONSE_INPUT_ID = "kc-response";
   var HS_EMAIL_INPUT_ID = "hs-email";
+  var HS_VERIFICATION_CODE_INPUT_ID = "hs-verification-code";
   var HS_EMAIL_FORM_GROUP_ID = "hs-email-form-group";
   // --> Constants
 
@@ -71,6 +75,10 @@
     return document.getElementById(HS_EMAIL_INPUT_ID);
   }
 
+  function getHsVerificationFormInput() {
+    return document.getElementById(HS_VERIFICATION_CODE_INPUT_ID);
+  }
+
   function getEmailFormGroup() {
     return document.getElementById(HS_EMAIL_FORM_GROUP_ID);
   }
@@ -81,6 +89,10 @@
 
   function getProvidePlainEmailForm() {
     return document.getElementById(KC_PROVIDE_PLAIN_EMAIL_FORM_ID);
+  }
+
+  function getEmailVerificationForm() {
+    return document.getElementById(KC_EMAIL_VERIFICATION_CODE_FORM_ID);
   }
 
   // --> Selectors
@@ -94,6 +106,11 @@
   function isEmailValid() {
     const inputElement = getHsEmailInput();
     return isTextValidEmail(inputElement.value);
+  }
+
+  function cleanVerificationCode() {
+    const inputElement = getHsVerificationFormInput();
+    inputElement.value = String(inputElement.value).replace(/\D/g, "");
   }
 
   function isDeclined() {
@@ -117,6 +134,10 @@
 
   function isPlainEmailProviderTemplate() {
     return !!getProvidePlainEmailForm();
+  }
+
+  function isEmailVerificationForm() {
+    return !!getEmailVerificationForm();
   }
 
   function getAndShowErrors() {
@@ -153,6 +174,11 @@
     event.preventDefault();
     var responseInput = getResponseInput();
     responseInput.setAttribute("value", event.target.getAttribute("value"));
+    if (isEmailVerificationForm()) {
+      cleanVerificationCode();
+      getEmailVerificationForm().submit();
+      return;
+    }
     if (isPlainEmailProviderTemplate()) {
       const emailIsValid = isEmailValid();
       toggleEmailError(emailIsValid);

--- a/helsinki/login/verification-code.ftl
+++ b/helsinki/login/verification-code.ftl
@@ -1,21 +1,26 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout; section>
-    <#if section = "header">
-        Verify your email address
-    <#elseif section = "form">
-        <p>You need to verify your email address.  We sent an email that contains a verification code.  Please enter this code into the input below.
-	<form class="form-actions" id="kc-verification-code-dialog-form" action="${url.loginAction}" method="post">
-      <div id="hs-verification-code-form-group">
-        <div class="hds-text-input" id="hs-verification-code-form-group" class="${properties.kcFormGroupClass!}">
-            <label class="hds-text-input__label" for="hs-verification-code">Verification Code</label>
-            <input class="hds-text-input__input" type="text" name="code" id="hs-verification-code" placeholder="1234" value=""/>
+  <#if section = "header">
+      ${msg("verificationCodeFormTitle")}
+  <#elseif section = "form">
+
+    <#assign verificationCodeErrorClassname=((validationErrors.code)??)?then(properties.kcFormGroupHasErrorClass,'') />
+    
+    <div>
+      <p>${msg("verificationCodeFormText")}</p>
+		</div>
+    <form class="form-actions" id="kc-email-verification-code-form" action="${url.loginAction}" method="post">
+      <div class="${properties.kcFormGroupClass!} ${verificationCodeErrorClassname}">
+        <div class="hds-text-input">
+          <label class="hds-text-input__label" for="hs-verification-code">${msg("verificationCodeFormLabel")}</label>
+          <input class="hds-text-input__input" type="text" name="code" id="hs-verification-code" placeholder="123456" value=""/>
+          <span class="hs-error-message" role="alert">${msg("verificationCodeFormError")}</span>
         </div>
       </div>
       <div class="wide-buttons">
-			  <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" id="kc-accept" type="submit" value="accept">${msg("profileAcceptButtonText")}</button>
-			  <button class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" id="kc-decline" type="submit" value="decline">${msg("profileDeclineButtonText")}</button>
+        <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" id="kc-accept" type="submit" value="accept">${msg("continue")}</button>
         <input type="hidden" name="response" id="kc-response" value="" />
       </div>
     </form>
-   </#if>       
+  </#if>       
 </@layout.registrationLayout>


### PR DESCRIPTION
This PR includes the form where user inserts the verification code received via email. The verification code can include only numbers and the value is "cleaned" when submitted. This makes copying the code from email easier as copying might include spaces invisible to user.