### PR TITLE
HP-940: verification emails

### DIFF
--- a/helsinki/email/html/email-verification-with-code.ftl
+++ b/helsinki/email/html/email-verification-with-code.ftl
@@ -1,0 +1,11 @@
+<#import "template.ftl" as layout>
+<@layout.emailLayout; section>
+  <#if section = "title">
+      ${kcSanitize(msg("emailVerificationCodeTitle"))?no_esc}
+  <#elseif section = "content">
+    ${kcSanitize(msg("emailVerificationBodyCodeHtml"))?no_esc}
+    <p style="font-size:28px;"><b>${code}</b></p>
+  <#elseif section = "footer">
+    ${kcSanitize(msg("emailVerificationCodeFooterHtml"))?no_esc}
+  </#if>
+</@layout.emailLayout>

--- a/helsinki/email/html/template.ftl
+++ b/helsinki/email/html/template.ftl
@@ -1,0 +1,69 @@
+<#macro emailLayout>
+<!DOCTYPE html>
+<html lang="${msg("emailLangCode")}" xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      <meta name="x-apple-disable-message-reformatting">
+      <title></title>
+      <!--[if mso]>
+      <noscript>
+          <xml>
+              <o:OfficeDocumentSettings>
+                  <o:PixelsPerInch>96</o:PixelsPerInch>
+              </o:OfficeDocumentSettings>
+          </xml>
+      </noscript>
+      <![endif]-->
+  </head>
+  <body style="margin:0;padding:0;">
+      <table role="presentation" style="width:100%;background:#ffffff;color:#1d1d1d;${properties.tableResetStyle}" border="0" cellpadding="0" cellspacing="0">
+          <tr>
+              <td align="left" valign="top" style="background:url('https://i.ibb.co/XFTzQ4f/koros.png');background-repeat:repeat-x;width:100%;line-height:47px;height:47px;${properties.emptyCellResetStyle}">
+                &nbsp;
+              </td>
+          </tr>
+          <tr>
+              <td align="left" valign="top" style="line-height:40px;height:40px;${properties.emptyCellResetStyle}">
+                  &nbsp;
+              </td>
+          </tr>
+          <tr>
+              <td align="left" valign="top" style="${properties.cellPaddingStyle}">
+                  <table style="${properties.tableResetStyle}" border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                      <td align="left" valign="middle" style="line-height:0px;height:44px;${properties.emptyCellResetStyle}">
+                          <img src="https://i.ibb.co/qDmRmpc/${msg("logoImage")}.png" height="44" alt="Logo" style="width:auto;display:block;" >
+                      </td>
+                      <td align="left" valign="middle" style="height:44px;padding:0px 0px 8px 14px;${properties.fontAdjustmentsTextStyle}font-size:22px;line-height:44px;">
+                          ${msg("profile")}
+                      </td>
+                  </tr>
+                  </table>
+              </td>
+          </tr>
+          <tr>
+              <td align="left" valign="top" style="${properties.cellPaddingStyle}">
+                  <div style="${properties.titleTextStyle}${properties.fontAdjustmentsTextStyle}"><#nested "title"></div>
+              </td>
+          </tr>
+          <tr>
+              <td align="left" valign="top" style="${properties.cellPaddingStyle}${properties.contentTextStyle}${properties.fontAdjustmentsTextStyle}">
+                  <#nested "content">
+              </td>
+          </tr>
+          <tr>
+              <td align="left" valign="top" style="line-height:10px;height:10px;${properties.emptyCellResetStyle}">
+                  &nbsp;
+              </td>
+          </tr>
+          <tr>
+              <td align="left" valign="top" style="${properties.cellPaddingStyle}${properties.contentTextStyle}${properties.fontAdjustmentsTextStyle}">
+                  <div style="${properties.footerBorderStyle}">&nbsp;</div>
+                  <#nested "footer">
+              </td>
+          </tr>
+      </table>
+  </body>
+</html>
+</#macro>

--- a/helsinki/email/messages/messages_en.properties
+++ b/helsinki/email/messages/messages_en.properties
@@ -1,10 +1,10 @@
 # encoding: utf-8
 emailVerificationSubject = Verify email
 emailVerificationBody = Someone has created a Helsinki account with this email address. If this was you, click the link below to verify your email address\n\n{0}\n\nThis link will expire within {3}.\n\nIf you didn''t create this account, just ignore this message.
-emailVerificationBodyHtml = <p>Someone has created a Helsinki account with this email address. If this was you, click the link below to verify your email address</p><p><a href={0}">Link to e-mail address verification</a></p><p>This link will expire within {3}.</p><p>If you didn''t create this account, just ignore this message.</p>
+emailVerificationBodyHtml = <p>Someone has created a Helsinki account with this email address. If this was you, click the link below to verify your email address</p><p><a href="{0}">Link to e-mail address verification</a></p><p>This link will expire within {3}.</p><p>If you didn''t create this account, just ignore this message.</p>
 passwordResetSubject = Reset password
 passwordResetBody = Someone just requested to change your Helsinki account''s password. If this was you, click on the link below to reset it.\n\n{0}\n\nThis link and code will expire within {3}.\n\nIf you don''t want to reset your password, just ignore this message and nothing will be changed.
-passwordResetBodyHtml = <p>Someone just requested to change your Helsinki account''s password. If this was you, click on the link below to reset it.</p><p><a href={0}">Link to reset password</a></p><p>This link will expire within {3}.</p><p>If you don''t want to reset your password, just ignore this message and nothing will be changed.</p>
+passwordResetBodyHtml = <p>Someone just requested to change your Helsinki account''s password. If this was you, click on the link below to reset it.</p><p><a href="{0}">Link to reset password</a></p><p>This link will expire within {3}.</p><p>If you don''t want to reset your password, just ignore this message and nothing will be changed.</p>
 linkExpirationFormatter.timePeriodUnit.seconds = seconds
 linkExpirationFormatter.timePeriodUnit.seconds.1 = second
 linkExpirationFormatter.timePeriodUnit.minutes = minutes
@@ -13,3 +13,11 @@ linkExpirationFormatter.timePeriodUnit.hours = hours
 linkExpirationFormatter.timePeriodUnit.hours.1 = hour
 linkExpirationFormatter.timePeriodUnit.days = days
 linkExpirationFormatter.timePeriodUnit.days.1 = day
+emailVerificationBodyCode = EN: Vahvista sähköpostiosoitteesi\\n\\nOlet luomassa Helsinki-profiilia. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.\\n\\nJos et ole luomassa Helsinki-profiilia voit jättää tämän viestin huomioimatta.\\n\\nHelsinki-profiilin vahvistuskoodi:\\n\\n{0}\\n\\n
+emailVerificationBodyCodeHtml = <p>EN: Olet luomassa Helsinki-profiilia. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.</p><p>Jos et ole luomassa Helsinki-profiilia voit jättää tämän viestin huomioimatta.</p><p>Helsinki-profiilin vahvistuskoodi:</p>
+emailVerificationCodeTitle = Verify your email address
+emailLangCode = en
+logoImage = helsinki-logo.png
+emailVerificationCodeFooter = EN: Tähän viestiin ei voi vastata
+emailVerificationCodeFooterHtml = <p>EN: Tähän viestiin ei voi vastata</p>
+profile = Profile

--- a/helsinki/email/messages/messages_fi.properties
+++ b/helsinki/email/messages/messages_fi.properties
@@ -1,10 +1,10 @@
 # encoding: utf-8
 emailVerificationSubject = Vahvista sähköposti
 emailVerificationBody = Joku on luonut tälle sähköpostiosoitteelle Helsinki-tunnuksen. Jos se olit sinä, niin vahvista tunnus alla olevan linkin avulla.\n\n{0}\n\nTämä linkki on voimassa {3}.\n\nJos et ole pyytänyt Helsinki-tunnuksen luomista itsellesi, voit jättää tämän viestin huomiotta.
-emailVerificationBodyHtml = <p>Joku on luonut tälle sähköpostiosoitteelle Helsinki-tunnuksen. Jos se olit sinä, niin vahvista tunnus alla olevan linkin avulla.</p><p><a href={0}">Vahvista sähköpostiosoite</a></p><p>Tämä linkki on voimassa {3}.</p><p>Jos et ole pyytänyt Helsinki-tunnuksen luomista itsellesi, voit jättää tämän viestin huomiotta.</p>
+emailVerificationBodyHtml = <p>Joku on luonut tälle sähköpostiosoitteelle Helsinki-tunnuksen. Jos se olit sinä, niin vahvista tunnus alla olevan linkin avulla.</p><p><a href="{0}">Vahvista sähköpostiosoite</a></p><p>Tämä linkki on voimassa {3}.</p><p>Jos et ole pyytänyt Helsinki-tunnuksen luomista itsellesi, voit jättää tämän viestin huomiotta.</p>
 passwordResetSubject = Vaihda salasana
 passwordResetBody = Saimme pyynnön muuttaa Helsinki-tunnuksesi salasanan. Jos pyysit salasanan muuttamista, pääset tekemään sen tällä linkillä.\n\n{0}\n\nTämä linkki on voimassa {3}.\n\nJos et halua muuttaa salasanaasi tai et ole pyytänyt salasanan muuttamista itse, voit jättää tämän viestin huomiotta ja jatkaa tunnuksesi käyttöä.
-passwordResetBodyHtml = <p>Saimme pyynnön muuttaa Helsinki-tunnuksesi salasanan. Jos pyysit salasanan muuttamista, pääset tekemään sen tällä linkillä.</p><p><a href={0}">Muuta salasana</a></p><p>Tämä linkki on voimassa {3}.</p><p>Jos et halua muuttaa salasanaasi tai et ole pyytänyt salasanan vaihtoa itse, voit jättää tämän viestin huomiotta ja jatkaa tunnuksesi käyttöä.</p>
+passwordResetBodyHtml = <p>Saimme pyynnön muuttaa Helsinki-tunnuksesi salasanan. Jos pyysit salasanan muuttamista, pääset tekemään sen tällä linkillä.</p><p><a href="{0}">Muuta salasana</a></p><p>Tämä linkki on voimassa {3}.</p><p>Jos et halua muuttaa salasanaasi tai et ole pyytänyt salasanan vaihtoa itse, voit jättää tämän viestin huomiotta ja jatkaa tunnuksesi käyttöä.</p>
 linkExpirationFormatter.timePeriodUnit.seconds = sekuntia
 linkExpirationFormatter.timePeriodUnit.seconds.1 = sekunnin
 linkExpirationFormatter.timePeriodUnit.minutes = minuuttia
@@ -13,3 +13,11 @@ linkExpirationFormatter.timePeriodUnit.hours = tuntia
 linkExpirationFormatter.timePeriodUnit.hours.1 = tunnin
 linkExpirationFormatter.timePeriodUnit.days = päivää
 linkExpirationFormatter.timePeriodUnit.days.1 = päivän
+emailVerificationBodyCode = Vahvista sähköpostiosoitteesi\\n\\nOlet luomassa Helsinki-profiilia. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.\\n\\nJos et ole luomassa Helsinki-profiilia voit jättää tämän viestin huomioimatta.\\n\\nHelsinki-profiilin vahvistuskoodi:\\n\\n{0}\\n\\n
+emailVerificationBodyCodeHtml = <p>Olet luomassa Helsinki-profiilia. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.</p><p>Jos et ole luomassa Helsinki-profiilia voit jättää tämän viestin huomioimatta.</p><p>Helsinki-profiilin vahvistuskoodi:</p>
+emailVerificationCodeTitle = Vahvista sähköpostiosoitteesi
+emailLangCode = fi
+logoImage = helsinki-logo-sv.png
+emailVerificationCodeFooter = Tähän viestiin ei voi vastata
+emailVerificationCodeFooterHtml = <p>Tähän viestiin ei voi vastata</p>
+profile = Profiili

--- a/helsinki/email/messages/messages_sv.properties
+++ b/helsinki/email/messages/messages_sv.properties
@@ -1,10 +1,10 @@
 # encoding: utf-8
 emailVerificationSubject = Verifiera e-post
 emailVerificationBody = Någon har skapat ett Helsingfors-konto med den här e-postadressen. Om det var du, klicka då på länken nedan för att verifiera din e-postadress\n\n{0}\n\nDen här länken kommer att upphöra inom {3}.\n\nOm det inte var du som skapade det här kontot, ignorera i så fall det här meddelandet.
-emailVerificationBodyHtml = <p>Någon har skapat ett Helsingfors-konto med den här e-postadressen. Om det var du, klicka då på länken nedan för att verifiera din e-postadress</p><p><a href={0}">Verifiera e-post</a></p><p>Den här länken går ut inom {3}.</p><p>Om det inte var du som skapade det här kontot, ignorera i så fall det här meddelandet.</p>
+emailVerificationBodyHtml = <p>Någon har skapat ett Helsingfors-konto med den här e-postadressen. Om det var du, klicka då på länken nedan för att verifiera din e-postadress</p><p><a href="{0}">Verifiera e-post</a></p><p>Den här länken går ut inom {3}.</p><p>Om det inte var du som skapade det här kontot, ignorera i så fall det här meddelandet.</p>
 passwordResetSubject = Återställ lösenord
 passwordResetBody = Någon har precis bett om att ändra lösenord för ditt Helsingfors-konto. Om det var du, klicka då på länken nedan för att återställa ditt lösenord.\n\n{0}\n\nDen här länken och koden kommer att upphöra inom {3}.\n\nOm du inte vill återställa ditt lösenord, ignorera i så fall det här meddelandet så kommer inget att ändras.
-passwordResetBodyHtml = <p>Någon har precis bett om att ändra lösenord för ditt Helsingfors-konto. Om det var du, klicka då på länken nedan för att återsälla ditt lösenord.</p><p><a href={0}">Återställ lösenord</a></p><p>Den här länken och koden kommer att upphöra inom {3}.</p><p>Om du inte vill återställa ditt lösenord , ignorera i så fall det här meddelandet så kommer inget att ändras.</p>
+passwordResetBodyHtml = <p>Någon har precis bett om att ändra lösenord för ditt Helsingfors-konto. Om det var du, klicka då på länken nedan för att återsälla ditt lösenord.</p><p><a href="{0}">Återställ lösenord</a></p><p>Den här länken och koden kommer att upphöra inom {3}.</p><p>Om du inte vill återställa ditt lösenord , ignorera i så fall det här meddelandet så kommer inget att ändras.</p>
 linkExpirationFormatter.timePeriodUnit.seconds = sekunder
 linkExpirationFormatter.timePeriodUnit.seconds.1 = sekund
 linkExpirationFormatter.timePeriodUnit.minutes = minuter
@@ -13,3 +13,11 @@ linkExpirationFormatter.timePeriodUnit.hours = timmar
 linkExpirationFormatter.timePeriodUnit.hours.1 = timme
 linkExpirationFormatter.timePeriodUnit.days = dagar
 linkExpirationFormatter.timePeriodUnit.days.1 = dag
+emailVerificationBodyCode = SV: Vahvista sähköpostiosoitteesi\\n\\nOlet luomassa Helsinki-profiilia. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.\\n\\nJos et ole luomassa Helsinki-profiilia voit jättää tämän viestin huomioimatta.\\n\\nHelsinki-profiilin vahvistuskoodi:\\n\\n{0}\\n\\n
+emailVerificationBodyCodeHtml = <p>SV: Olet luomassa Helsinki-profiilia. Käytä allaolevaa koodia vahvistaaksesi sähköpostiosoitteesi.</p><p>Jos et ole luomassa Helsinki-profiilia voit jättää tämän viestin huomioimatta.</p><p>Helsinki-profiilin vahvistuskoodi:</p>
+emailVerificationCodeTitle = SV: Vahvista sähköpostiosoitteesi 
+emailLangCode = sv
+logoImage = helsinki-logo.png
+emailVerificationCodeFooter = SV: Tähän viestiin ei voi vastata
+emailVerificationCodeFooterHtml = <p>SV: Tähän viestiin ei voi vastata</p>
+profile = Profil

--- a/helsinki/email/text/email-verification-with-code.ftl
+++ b/helsinki/email/text/email-verification-with-code.ftl
@@ -1,0 +1,7 @@
+<#ftl output_format="plainText">
+<#assign lines = msg("emailVerificationBodyCode",code)?split("\\n") />
+<#list lines as line>
+${line}
+</#list>
+
+${msg("emailVerificationCodeFooter")}

--- a/helsinki/email/theme.properties
+++ b/helsinki/email/theme.properties
@@ -1,2 +1,9 @@
 parent=base
 locales=fi,sv,en
+cellPaddingStyle=padding:10px 10px 0 10px;
+fontAdjustmentsTextStyle=-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;
+contentTextStyle=font-size:16px;line-height:22px;
+titleTextStyle=font-size:26px;line-height:32px;padding:20px 0 0;
+emptyCellResetStyle=mso-line-height-rule:exactly;font-size:0;padding:0;
+footerBorderStyle=border-top:1px solid #cfcfcf;line-height:1px;height:1px;
+tableResetStyle=border-collapse:collapse;border:0;border-spacing:0;padding:0;


### PR DESCRIPTION
Email templates for the verification codes. Created also a common base template file for these and future emails.

The images are now stored in a cloud service, because right now Keycloak cannot pass url.resourcesPath to email templates, so urls referring to the server's domain cannot be created. 