### PR TITLE
HP-1020 Added texts for unreclaimable email

### DIFF
--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -102,3 +102,4 @@ givenEmailIsInUseTitle = EN: Antamasi sähköpostiosoite on jo käytössä
 givenEmailIsInUseText = EN: Toinen käyttäjä on jo antanut saman sähköpostiosoitteen <strong>{0}</strong>. Se on vahvistamatta, joten voit vahvistamalla siirtää sen itsellesi. Tarkista ensin, että kirjoitit sähköpostiosoitteen oikein.
 giveAnotherEmail = EN: Anna toinen sähköpostiosoite
 reclaimEmail = EN: Vahvista ja siirrä sähköpostiosoite itsellesi
+givenEmailIsInUseAndVerifiedText = EN: Sähköpostiosoite <strong>{0}</strong> on jo toisen käyttäjän vahvistama. Palaa alla olevasta painikkeesta edelliseen näkymään ja anna toinen sähköpostiosoite.

--- a/helsinki/login/messages/messages_fi.properties
+++ b/helsinki/login/messages/messages_fi.properties
@@ -102,3 +102,4 @@ givenEmailIsInUseTitle = Antamasi sähköpostiosoite on jo käytössä
 givenEmailIsInUseText = Toinen käyttäjä on jo antanut saman sähköpostiosoitteen <strong>{0}</strong>. Se on vahvistamatta, joten voit vahvistamalla siirtää sen itsellesi. Tarkista ensin, että kirjoitit sähköpostiosoitteen oikein.
 giveAnotherEmail = Anna toinen sähköpostiosoite
 reclaimEmail = Vahvista ja siirrä sähköpostiosoite itsellesi
+givenEmailIsInUseAndVerifiedText = Sähköpostiosoite <strong>{0}</strong> on jo toisen käyttäjän vahvistama. Palaa alla olevasta painikkeesta edelliseen näkymään ja anna toinen sähköpostiosoite.

--- a/helsinki/login/messages/messages_sv.properties
+++ b/helsinki/login/messages/messages_sv.properties
@@ -102,3 +102,4 @@ givenEmailIsInUseTitle = SV: Antamasi sähköpostiosoite on jo käytössä
 givenEmailIsInUseText = SV: Toinen käyttäjä on jo antanut saman sähköpostiosoitteen <strong>{0}</strong>. Se on vahvistamatta, joten voit vahvistamalla siirtää sen itsellesi. Tarkista ensin, että kirjoitit sähköpostiosoitteen oikein.
 giveAnotherEmail = SV: Anna toinen sähköpostiosoite
 reclaimEmail = SV: Vahvista ja siirrä sähköpostiosoite itsellesi
+givenEmailIsInUseAndVerifiedText = SV: Sähköpostiosoite <strong>{0}</strong> on jo toisen käyttäjän vahvistama. Palaa alla olevasta painikkeesta edelliseen näkymään ja anna toinen sähköpostiosoite.

--- a/helsinki/login/reclaim-unconfirmed-email.ftl
+++ b/helsinki/login/reclaim-unconfirmed-email.ftl
@@ -5,7 +5,11 @@
     <#elseif section = "form">
         <form id="kc-reclaim-email-form" action="${url.loginAction}" method="post">
             <div class="${properties.kcFormGroupClass!}">
+            <#if canReclaim >
               <p>${kcSanitize(msg("givenEmailIsInUseText",(email!'')))?no_esc}</p>
+            <#else>
+              <p>${kcSanitize(msg("givenEmailIsInUseAndVerifiedText",(email!'')))?no_esc}</p>
+            </#if>
             </div>
             <div class="${properties.kcFormGroupClass!} wide-buttons">
                 <button type="submit" class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" name="submitAction" id="updateProfile" value="updateProfile">${msg("giveAnotherEmail")}</button>


### PR DESCRIPTION
If an email has been verified by another user, it cannot be reclaimed and user must give another email.