### PR TITLE
HP-1280 removee Zocial

### DIFF
--- a/helsinki/login/login.ftl
+++ b/helsinki/login/login.ftl
@@ -53,9 +53,17 @@
         </div>
         <#if realm.password && social.providers??>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}">
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 4>${properties.kcFormSocialAccountDoubleListClass!}</#if>">
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
                     <#list social.providers as p>
-                        <li class="${properties.kcFormSocialAccountListLinkClass!}"><a href="${p.loginUrl}" id="zocial-${p.alias}" class="zocial ${p.providerId}"> <span>${p.displayName}</span></a></li>
+                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
+                                type="button" href="${p.loginUrl}">
+                            <#if p.iconClasses?has_content>
+                                <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
+                                <span class="${properties.kcFormSocialAccountNameClass!} kc-social-icon-text">${p.displayName!}</span>
+                            <#else>
+                                <span class="${properties.kcFormSocialAccountNameClass!}">${p.displayName!}</span>
+                            </#if>
+                        </a>
                     </#list>
                 </ul>
             </div>

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -2,7 +2,7 @@ parent=keycloak
 import=common/keycloak
 locales=fi,sv,en
 # Inherit styles from parent and use custom css files
-styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/hds.css css/shared.css css/hs-login.css
+styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css css/login.css css/hds.css css/shared.css css/hs-login.css
 
 # Add custom JS hooks
 scripts=js/customRegistrationValidation.js js/inputReset.js js/profileCreationValidation.js


### PR DESCRIPTION
Zocial was removed from Keycloak and started to produce 404 errors in helsinki-theme.

Removed all references and usages.

Note: Social logins are disabled on not visible anywhere in Helsinki Tunnistus.