### PR TITLE
Prevent template error when baseUrl is missing

### DIFF
--- a/helsinki/email/html/template.ftl
+++ b/helsinki/email/html/template.ftl
@@ -1,5 +1,5 @@
 <#macro emailLayout>
-<#assign imagePath="${baseUrl}${url.resourcesPath}/img" />
+<#assign imagePath="${baseUrl!}${url.resourcesPath}/img" />
 <!DOCTYPE html>
 <html lang="${msg("emailLangCode")}" xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
   <head>


### PR DESCRIPTION
If baseUrl is missing the default value will be an empty string.

This is just a temporary error mitigation and doesn't make the images work if the baseUrl is missing.