### PR TITLE
Construct image path so that it works everywhere

### DIFF
--- a/helsinki/email/html/template.ftl
+++ b/helsinki/email/html/template.ftl
@@ -1,5 +1,5 @@
 <#macro emailLayout>
-<#assign imagePath="${baseUrl!}${url.resourcesPath}/img" />
+<#assign imagePath="${url.resourcesUrl}/img" />
 <!DOCTYPE html>
 <html lang="${msg("emailLangCode")}" xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
   <head>


### PR DESCRIPTION
The `baseUrl` attribute was custom made and only worked on some email templates. Keycloak already provides the `url` attribute which contains all kinds of handy properties. In this case the `resourcesUrl` is the correct property as it contains the full resource URL, including schema and domain.

This change needs a corresponding change in the Keycloak plugin, where it constructs the `url` attribute correctly, including protocol and domain.