### PR TITLE
HP-1438: Updated the broken urls for Privacy policy links.

### DIFF
--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -15,7 +15,7 @@ firstName = First name
 lastName = Last name
 passwordConfirm = Confirm password
 doAcknowledgeResources = I have read the <a href="{0}" {2}>the personal data file description</a> and <a href="{1}" {2}>the data privacy principles</a> of the City of Helsinki
-doAcknowledgeResourcesPrivacyPolicyLink = https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf
+doAcknowledgeResourcesPrivacyPolicyLink = https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Sahkoisten%20asiointipalveluiden%20rekisteri.pdf
 doAcknowledgeResourcesyDataProtectionLink = https://www.hel.fi/helsinki/en/administration/information/data-protection
 doAcknowledgeAge = I am at least 13 years old
 doAcknowledgeAgeError = You must be at least 13 years old to obtain a Helsinki profile user ID

--- a/helsinki/login/messages/messages_fi.properties
+++ b/helsinki/login/messages/messages_fi.properties
@@ -15,7 +15,7 @@ firstName = Etunimi
 lastName = Sukunimi
 passwordConfirm = Vahvista salasana
 doAcknowledgeResources = Olen tutustunut Helsingin kaupungin <a href="{0}" {2}>rekisteriselosteeseen</a> ja <a href="{1}" {2}>tietosuojakäytäntöön.</a>
-doAcknowledgeResourcesPrivacyPolicyLink = https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf
+doAcknowledgeResourcesPrivacyPolicyLink = https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Sahkoisten%20asiointipalveluiden%20rekisteri.pdf
 doAcknowledgeResourcesyDataProtectionLink = https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/tietoa-helsingista/tietosuoja/
 doAcknowledgeAge = Olen vähintään 13-vuotias
 doAcknowledgeAgeError = Helsinki-profiilin käyttäjätunnuksen hankkiminen edellyttää vähintään 13 vuoden iän

--- a/helsinki/login/messages/messages_sv.properties
+++ b/helsinki/login/messages/messages_sv.properties
@@ -15,7 +15,7 @@ firstName = Förnamn
 lastName = Efternamn
 passwordConfirm = Bekräfta lösenordet
 doAcknowledgeResources = Jag har bekantat mig med Helsingfors stads <a href="{0}" {2}>registerbeskrivning</a> och <a href="{1}" {2}>sekretesspolicy</a>.
-doAcknowledgeResourcesPrivacyPolicyLink = https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/S%C3%A4hk%C3%B6isten%20asiointipalveluiden%20rekisteri.pdf
+doAcknowledgeResourcesPrivacyPolicyLink = https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Register%20over%20e-tjanster.pdf
 doAcknowledgeResourcesyDataProtectionLink = https://www.hel.fi/helsinki/sv/stad-och-forvaltning/information/dataskydd
 doAcknowledgeAge = Jag är minst 13 år gammal
 doAcknowledgeAgeError = Ett användarnamn för en Helsinki-profil förutsätter att du är minst 13 år.


### PR DESCRIPTION
Urls copied from Profile UI.

There still is no English version, so using Finnish instead.