### PR TITLE
HP-1499: Remove patternfly usage

### DIFF
--- a/helsinki/login/resources/css/hds.css
+++ b/helsinki/login/resources/css/hds.css
@@ -2484,18 +2484,8 @@ we can not use this position for the actual button as it's in incorrect source o
   font-style: italic;
   text-rendering: optimizeLegibility; }
 
-label.hds-checkbox__label {
-  font-weight: normal; }
-
 a.hds-button {
   font-size: 1rem; }
-
-input[type="checkbox"].hds-checkbox__input {
-  margin-top: 0; }
-
-input[type="checkbox"].hds-checkbox__input:focus,
-input[type="radio"].hds-checkbox__input:focus {
-  outline: none; }
 
 .hs-has-error.hs-form-group .hds-checkbox .hds-checkbox__label,
 .hs-has-error.hs-form-group .hds-text-input .hds-text-input__label {

--- a/helsinki/login/resources/css/hs-login.css
+++ b/helsinki/login/resources/css/hs-login.css
@@ -112,6 +112,16 @@ a {
   width: 100%;
   margin-bottom: 10px; }
 
+.login-pf-page {
+  padding-top: 1.5rem; }
+
+.login-pf-page .card-pf {
+  margin-bottom: 0; }
+
+.login-pf-page .login-pf-header {
+  display: flex;
+  flex-direction: column; }
+
 .login-pf {
   background: #9fc9eb; }
 

--- a/helsinki/login/resources/css/shared.css
+++ b/helsinki/login/resources/css/shared.css
@@ -1,3 +1,81 @@
+* {
+  box-sizing: border-box; }
+
+*:before,
+*:after {
+  box-sizing: border-box; }
+
+body {
+  line-height: 1.5;
+  color: #1a1a1a; }
+
+img {
+  vertical-align: middle;
+  border: 0; }
+
+label {
+  max-width: 100%; }
+
+input[type="radio"],
+input[type="checkbox"] {
+  line-height: normal; }
+
+.clearfix:after,
+.dl-horizontal dd:after,
+.container:after,
+.container-fluid:after,
+.row:after,
+.form-horizontal .form-group:after,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:after,
+.nav:after,
+.navbar:after,
+.navbar-header:after,
+.navbar-collapse:after,
+.pager:after,
+.panel-body:after,
+.modal-header:after,
+.modal-footer:after {
+  clear: both; }
+
+.clearfix:before,
+.clearfix:after,
+.dl-horizontal dd:before,
+.dl-horizontal dd:after,
+.container:before,
+.container:after,
+.container-fluid:before,
+.container-fluid:after,
+.row:before,
+.row:after,
+.form-horizontal .form-group:before,
+.form-horizontal .form-group:after,
+.btn-toolbar:before,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:before,
+.btn-group-vertical > .btn-group:after,
+.nav:before,
+.nav:after,
+.navbar:before,
+.navbar:after,
+.navbar-header:before,
+.navbar-header:after,
+.navbar-collapse:before,
+.navbar-collapse:after,
+.pager:before,
+.pager:after,
+.panel-body:before,
+.panel-body:after,
+.modal-header:before,
+.modal-header:after,
+.modal-footer:before,
+.modal-footer:after {
+  display: table;
+  content: " "; }
+
+.card-pf {
+  background: #fff; }
+
 #kc-form-buttons {
   margin-top: 3rem; }
   #kc-form-buttons:not(:last-child) {

--- a/helsinki/login/theme.properties
+++ b/helsinki/login/theme.properties
@@ -2,7 +2,7 @@ parent=keycloak
 import=common/keycloak
 locales=fi,sv,en
 # Inherit styles from parent and use custom css files
-styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css css/login.css css/hds.css css/shared.css css/hs-login.css
+styles=css/login.css css/hds.css css/shared.css css/hs-login.css
 
 # Add custom JS hooks
 scripts=js/customRegistrationValidation.js js/inputReset.js js/profileCreationValidation.js

--- a/sass/hds/keycloak-overrides.scss
+++ b/sass/hds/keycloak-overrides.scss
@@ -1,25 +1,6 @@
 @import "../theme";
 
-// Ensure that patternfly does not set a bold font weight for checkbox
-// labels.
-label.hds-checkbox__label {
-  font-weight: normal;
-}
-
 // Make sure that button links get the correct font size.
 a.hds-button {
   font-size: $fontsize-body-m;
-}
-
-// Make sure that patternfly doesn't add a margin to hds checkboxes
-// which break layout.
-input[type="checkbox"].hds-checkbox__input {
-  margin-top: 0;
-}
-// Fix ghost checkbox issue when checkbox/radio has focus
-// HDS changes input position to absolute and hides actual input
-// which causes weird issues with patternfly's (keycloak base css) outline declarations
-input[type="checkbox"].hds-checkbox__input:focus,
-input[type="radio"].hds-checkbox__input:focus {
-  outline: none;
 }

--- a/sass/login/keycloak-overrides.scss
+++ b/sass/login/keycloak-overrides.scss
@@ -6,6 +6,19 @@ $card-padding-mobile-vertical: $spacing-layout-l;
 $card-padding-tablet: $spacing-layout-m;
 $card-padding-tablet-vertical: $spacing-layout-xl;
 
+.login-pf-page {
+  padding-top: $spacing-layout-xs;
+}
+
+.login-pf-page .card-pf {
+  margin-bottom: 0;
+}
+
+.login-pf-page .login-pf-header {
+  display: flex;
+  flex-direction: column;
+}
+
 // Override the default background image with a solid color
 .login-pf {
   background: $page-background;

--- a/sass/shared/custom.scss
+++ b/sass/shared/custom.scss
@@ -5,8 +5,7 @@
   font-family: $font-family-base;
 }
 
-// Set root font size to a value that HDS expects. Apply to body to
-// override a default font size patternfly applies to some elements.
+// Set root font size to a value that HDS expects.
 html,
 body {
   font-size: 16px;

--- a/sass/shared/keycloak-overrides.scss
+++ b/sass/shared/keycloak-overrides.scss
@@ -1,9 +1,95 @@
 @import "../theme";
 
+* {
+  box-sizing: border-box;
+}
+
+*:before,
+*:after {
+  box-sizing: border-box;
+}
+
+body {
+  line-height: $lineheight-l;
+  color: $color-black-90;
+}
+
+img {
+  vertical-align: middle;
+  border: 0;
+}
+
+label {
+  max-width: 100%;
+}
+
+input[type="radio"],
+input[type="checkbox"] {
+  line-height: normal;
+}
+
+.clearfix:after,
+.dl-horizontal dd:after,
+.container:after,
+.container-fluid:after,
+.row:after,
+.form-horizontal .form-group:after,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:after,
+.nav:after,
+.navbar:after,
+.navbar-header:after,
+.navbar-collapse:after,
+.pager:after,
+.panel-body:after,
+.modal-header:after,
+.modal-footer:after {
+  clear: both;
+}
+
+.clearfix:before,
+.clearfix:after,
+.dl-horizontal dd:before,
+.dl-horizontal dd:after,
+.container:before,
+.container:after,
+.container-fluid:before,
+.container-fluid:after,
+.row:before,
+.row:after,
+.form-horizontal .form-group:before,
+.form-horizontal .form-group:after,
+.btn-toolbar:before,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:before,
+.btn-group-vertical > .btn-group:after,
+.nav:before,
+.nav:after,
+.navbar:before,
+.navbar:after,
+.navbar-header:before,
+.navbar-header:after,
+.navbar-collapse:before,
+.navbar-collapse:after,
+.pager:before,
+.pager:after,
+.panel-body:before,
+.panel-body:after,
+.modal-header:before,
+.modal-header:after,
+.modal-footer:before,
+.modal-footer:after {
+  display: table;
+  content: " ";
+}
+
+.card-pf {
+  background: #fff;
+}
+
 // Use correct whitespace for button container
 #kc-form-buttons {
   margin-top: $spacing-layout-m;
-
   &:not(:last-child) {
     margin-bottom: $spacing-layout-xs;
   }


### PR DESCRIPTION
Removed import from theme.properties

Copied actually used common styles to shared/keycloak-overrides.scss

Copied actually used login styles to login/keycloak-overrides.scss

Recreated .css files with build script.