### PR TITLE
Skeleton for service connection confirmation form

### DIFF
--- a/helsinki/login/service-connection-confirm-form.ftl
+++ b/helsinki/login/service-connection-confirm-form.ftl
@@ -1,0 +1,13 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout; section>
+    <#if section = "header">
+        FIXME: header
+    <#elseif section = "form">
+        <form id="kc-service-connection-confirm-form" action="${url.loginAction}" method="post">
+            <div>
+                <button id="kc-accept" type="submit" name="response" value="accept">${msg("profileAcceptButtonText")}</button>
+                <button id="kc-decline" type="submit" name="response" value="decline">${msg("profileDeclineButtonText")}</button>
+            </div>
+        </form>
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
The important part in this version is the contents of the form. It includes two buttons with correct names and values. Everything else, including any texts and styling, is missing.

Replaces #89.