### PR TITLE
Rename allowed data fields attribute

### DIFF
--- a/helsinki/login/service-connection-confirm-form.ftl
+++ b/helsinki/login/service-connection-confirm-form.ftl
@@ -6,7 +6,7 @@
         <div>Service: ${serviceName}</div>
         <div>
             <ul>
-            <#list serviceAllowedData as item>
+            <#list serviceAllowedDataFields as item>
                 <li>${item}</li>
             </#list>
             </ul>


### PR DESCRIPTION
Let's use the full term, allowed data fields, everywhere.