### PR TITLE
Add unallowed-session-login-method-info.ftl

### DIFF
--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -129,3 +129,5 @@ dataHandlingNote = You can later manage access to this information or delete it 
 readHelsinkiDocs = Please refer to the City of Helsinki’s <a href="{0}" {2}>file description</a>{3} and <a href="{1}" {2}>privacy policy</a>{3}.
 serviceDataUsageListTitleOldUser = The <strong>{0}</strong> service requests permission to access the following information on your profile:
 weUseInformationTitle = We use your information
+unallowedSessionLoginMethodTitle = EN: Yhteensopimaton kirjautumistapa
+unallowedSessionLoginMethodText = EN: Olet jo kirjautunut kirjautumistavalla joka ei käy tähän palveluun. Kirjaudu ensin ulos aiemmin käyttämästäsi palvelusta ja tee sitten sisäänkirjautuminen uudestaan.

--- a/helsinki/login/messages/messages_fi.properties
+++ b/helsinki/login/messages/messages_fi.properties
@@ -129,3 +129,5 @@ dataHandlingNote = Voit myöhemmin hallinnoida näiden tietojen käyttöä tai p
 readHelsinkiDocs = Tutustu Helsingin kaupungin <a href="{0}" {2}>rekisteriselosteeseen</a>{3} ja <a href="{1}" {2}>tietosuojakäytäntöön</a>{3}.
 serviceDataUsageListTitleOldUser = Palvelu <strong>{0}</strong> pyytää lupaa käyttää seuraavia tietoja profiilistasi:
 weUseInformationTitle = Käytämme tietojasi
+unallowedSessionLoginMethodTitle = Yhteensopimaton kirjautumistapa
+unallowedSessionLoginMethodText = Olet jo kirjautunut kirjautumistavalla joka ei käy tähän palveluun. Kirjaudu ensin ulos aiemmin käyttämästäsi palvelusta ja tee sitten sisäänkirjautuminen uudestaan.

--- a/helsinki/login/messages/messages_sv.properties
+++ b/helsinki/login/messages/messages_sv.properties
@@ -129,3 +129,5 @@ dataHandlingNote = Du kan senare förvalta användningen av dessa uppgifter elle
 readHelsinkiDocs = Se Helsingfors stads <a href="{0}" {2}>registerbeskrivning</a>{3} och <a href="{1}" {2}>dataskyddspraxis</a>{3}.
 serviceDataUsageListTitleOldUser = Tjänsten <strong>{0}</strong> begär tillstånd att använda följande uppgifter från din profil:
 weUseInformationTitle = Vi använder dina uppgifter
+unallowedSessionLoginMethodTitle = SV: Yhteensopimaton kirjautumistapa
+unallowedSessionLoginMethodText = SV: Olet jo kirjautunut kirjautumistavalla joka ei käy tähän palveluun. Kirjaudu ensin ulos aiemmin käyttämästäsi palvelusta ja tee sitten sisäänkirjautuminen uudestaan.

--- a/helsinki/login/unallowed-session-login-method-info.ftl
+++ b/helsinki/login/unallowed-session-login-method-info.ftl
@@ -1,0 +1,13 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "header">
+        ${kcSanitize(msg("unallowedSessionLoginMethodTitle"))?no_esc}
+    <#elseif section = "form">
+        <div id="kc-info-message">
+            <p class="instruction">${kcSanitize(msg("unallowedSessionLoginMethodText"))?no_esc}</p>
+            <#if backToApplicationUrl?has_content>
+                <p><a id="backToApplication" href="${backToApplicationUrl}">${kcSanitize(msg("backToApplication"))?no_esc}</a></p>
+            </#if>
+        </div>
+    </#if>
+</@layout.registrationLayout>


### PR DESCRIPTION
This is a simple info view, dedicated for informing the user that the session's current login method is not allowed by the client they are trying to authenticate with.