### PR TITLE
Add flag for removing the username in registration template

### DIFF
--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -53,7 +53,7 @@
                 </div>
             </div>
 
-          <#if !realm.registrationEmailAsUsername>
+          <#if !realm.registrationEmailAsUsername && !noUsername??>
             <div class="${properties.kcFormGroupClass!} ${messagesPerField.printIfExists('username',properties.kcFormGroupErrorClass!)}">
                 <div class="${properties.kcLabelWrapperClass!}">
                     <label for="username" class="${properties.kcLabelClass!}">${msg("username")}</label>


### PR DESCRIPTION
The username field can be removed from the registration template by setting the `noUsername` attribute to `true`.