### PR TITLE
HP-1017 Hide login methods that the current client doesn't support

### DIFF
--- a/helsinki/login/login.ftl
+++ b/helsinki/login/login.ftl
@@ -1,11 +1,21 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && social.providers??) showFeedbackLink=true; section>
+<#if client.attributes["helsinkitunnistus.loginmethods"]??>
+    <#assign clientLoginMethods = client.attributes["helsinkitunnistus.loginmethods"]?split("##") />
+    <#assign clientSupportsHelsinkiTunnus = clientLoginMethods?seq_contains("helsinki_tunnus") />
+    <#assign clientSocialProviders = social.providers?filter(p -> clientLoginMethods?seq_contains(p.alias)) />
+<#else>
+    <#assign clientSupportsHelsinkiTunnus = true />
+    <#assign clientSocialProviders = social.providers />
+</#if>
+
+<@layout.registrationLayout displayInfo=social.displayInfo displayWide=(realm.password && clientSocialProviders??) showFeedbackLink=true; section>
     <#if section = "header">
         ${msg("doLogIn")}
     <#elseif section = "form">
-    <div id="kc-form" <#if realm.password && social.providers??>class="${properties.kcContentWrapperClass!}"</#if>>
-      <div id="kc-form-wrapper" <#if realm.password && social.providers??>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
-        <#if realm.password>
+
+    <div id="kc-form" <#if realm.password && clientSocialProviders??>class="${properties.kcContentWrapperClass!}"</#if>>
+      <div id="kc-form-wrapper" <#if realm.password && clientSocialProviders??>class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}"</#if>>
+        <#if realm.password && clientSupportsHelsinkiTunnus>
             <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <div class="${properties.kcFormGroupClass!}">
                     <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
@@ -51,11 +61,11 @@
             </form>
         </#if>
         </div>
-        <#if realm.password && social.providers??>
+        <#if realm.password && clientSocialProviders??>
             <div id="kc-social-providers" class="${properties.kcFormSocialAccountContentClass!} ${properties.kcFormSocialAccountClass!}">
-                <ul class="${properties.kcFormSocialAccountListClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
-                    <#list social.providers as p>
-                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if social.providers?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
+                <ul class="${properties.kcFormSocialAccountListClass!} <#if clientSocialProviders?size gt 3>${properties.kcFormSocialAccountListGridClass!}</#if>">
+                    <#list clientSocialProviders as p>
+                        <a id="social-${p.alias}" class="${properties.kcFormSocialAccountListButtonClass!} <#if clientSocialProviders?size gt 3>${properties.kcFormSocialAccountGridItem!}</#if>"
                                 type="button" href="${p.loginUrl}">
                             <#if p.iconClasses?has_content>
                                 <i class="${properties.kcCommonLogoIdP!} ${p.iconClasses!}" aria-hidden="true"></i>
@@ -70,7 +80,7 @@
         </#if>
       </div>
     <#elseif section = "info" >
-        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
+        <#if realm.password && realm.registrationAllowed && !registrationDisabled?? && clientSupportsHelsinkiTunnus>
             <div id="kc-registration">
                 <span class="${properties.hsSubtitle!}">${msg("noAccount")}</span>
                 <a tabindex="6" class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" href="${url.registrationUrl}">${msg("doRegister")}</a>


### PR DESCRIPTION
The login methods that a client supports are listed in its configuration. That configuration is now used to exclude parts of the login form, showing only the relevant parts for the supported login methods.

This commit doesn't modify the styling of the elements. Only the logic is included here.