### PR TITLE
Add terms and service info to registration template

### DIFF
--- a/helsinki/login/messages/messages_en.properties
+++ b/helsinki/login/messages/messages_en.properties
@@ -11,6 +11,7 @@ noAccount = New user? The Helsinki profile user ID is in trial use and is yet to
 doRegister = Create a new user ID for your Helsinki profile
 invalidUserMessage = Invalid username or password
 registerTitle = Create a new user ID for your Helsinki profile
+registerTermsText = EN: Luo Helsinki-profiili ja siihen liitetty tunnus. Tietosi löytyvät jatkossa kätevästi yhdestä paikasta.<br/><br/>Palvelut, joille annat luvan pääsevät lukemaan profiilin tietojasi.
 firstName = First name
 lastName = Last name
 passwordConfirm = Confirm password

--- a/helsinki/login/messages/messages_fi.properties
+++ b/helsinki/login/messages/messages_fi.properties
@@ -11,6 +11,7 @@ noAccount = Uusi käyttäjä? Helsinki-profiilin käyttäjätunnus on koekäytö
 doRegister = Luo uusi käyttäjätunnus Helsinki-profiiliin
 invalidUserMessage = Väärä tunnus tai salasana
 registerTitle = Luo uusi käyttäjätunnus Helsinki-profiiliin
+registerTermsText = Luo Helsinki-profiili ja siihen liitetty tunnus. Tietosi löytyvät jatkossa kätevästi yhdestä paikasta.<br/><br/>Palvelut, joille annat luvan pääsevät lukemaan profiilin tietojasi.
 firstName = Etunimi
 lastName = Sukunimi
 passwordConfirm = Vahvista salasana

--- a/helsinki/login/messages/messages_sv.properties
+++ b/helsinki/login/messages/messages_sv.properties
@@ -11,6 +11,7 @@ noAccount = Ny användare? Användarnamnet för Helsingforsprofilen används på
 doRegister = Skapa ett nytt användarnamn i Helsingforsprofilen.
 invalidUserMessage = Ogiltigt användarnamn eller lösenord
 registerTitle = Skapa ett nytt användarnamn i Helsingforsprofilen.
+registerTermsText = SV: Luo Helsinki-profiili ja siihen liitetty tunnus. Tietosi löytyvät jatkossa kätevästi yhdestä paikasta.<br/><br/>Palvelut, joille annat luvan pääsevät lukemaan profiilin tietojasi.
 firstName = Förnamn
 lastName = Efternamn
 passwordConfirm = Bekräfta lösenordet

--- a/helsinki/login/register.ftl
+++ b/helsinki/login/register.ftl
@@ -3,6 +3,18 @@
     <#if section = "header">
         ${msg("registerTitle")}
     <#elseif section = "form">
+        <div id="kc-terms-text">
+            <p>${msg("registerTermsText")?no_esc}</p>
+            <#if (serviceName)??>
+                <p>${msg("serviceDataUsageListTitle", serviceName)?no_esc}</p>
+                <ul class="checked-list">
+                <#list serviceAllowedDataFields as item>
+                    <li>${item}</li>
+                </#list>
+                </ul>
+            </#if>
+       </div>
+
         <div id="hs-age-check-error" class="${properties.hsAlertClass!} ${properties.hsAlertErrorClass!}" style="display: none;">
             <div class="${properties.hsAlertLabelClass!}">
                 <span class="${properties.kcFeedbackErrorIcon!}"></span>


### PR DESCRIPTION
The registration terms text is new.

The service information is received in the same kind of way that is already present in `save-profile-confirm-dialog.ftl`.